### PR TITLE
fix(open-graph-inspector): resolve URL fetch bug and implement proxy validation

### DIFF
--- a/functions/api/fetch.js
+++ b/functions/api/fetch.js
@@ -1,0 +1,65 @@
+export async function onRequestGet(context) {
+  const { request } = context;
+  const { searchParams } = new URL(request.url);
+  const targetUrl = searchParams.get("url");
+
+  if (!targetUrl) {
+    return new Response("Missing url parameter", {
+      status: 400,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "text/plain; charset=utf-8"
+      }
+    });
+  }
+
+  try {
+    const parsedUrl = new URL(targetUrl);
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      return new Response("Invalid URL protocol. Only http and https are supported.", {
+        status: 400,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "text/plain; charset=utf-8"
+        }
+      });
+    }
+
+    // Use a standard browser User-Agent so we are less likely to get blocked by websites
+    const headers = new Headers();
+    headers.set(
+      "User-Agent",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OneFileTools/1.0"
+    );
+    headers.set(
+      "Accept",
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+    );
+    headers.set("Accept-Language", "en-US,en;q=0.5");
+
+    const response = await fetch(targetUrl, {
+      method: "GET",
+      headers,
+      redirect: "follow"
+    });
+
+    const text = await response.text();
+
+    return new Response(text, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("content-type") || "text/html; charset=utf-8",
+        "Access-Control-Allow-Origin": "*",
+        "X-Proxy-Success": "true"
+      }
+    });
+  } catch (error) {
+    return new Response(`Proxy Error: ${error.message}`, {
+      status: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "text/plain; charset=utf-8"
+      }
+    });
+  }
+}

--- a/tools/open-graph-inspector.html
+++ b/tools/open-graph-inspector.html
@@ -1802,6 +1802,19 @@
         }
       }
 
+      function looksLikeHtml(text) {
+        if (!text) return false;
+        const trimmed = text.trim().toLowerCase();
+        return (
+          trimmed.startsWith("<!doctype") ||
+          trimmed.includes("<html") ||
+          trimmed.includes("<body") ||
+          trimmed.includes("<head") ||
+          trimmed.includes("<meta") ||
+          trimmed.includes("<title")
+        );
+      }
+
       /* -------------------------------------------------------
    14. FETCH PAGE
    ------------------------------------------------------- */
@@ -1819,7 +1832,14 @@
                 () =>
                   fetch("/api/fetch?url=" + encodeURIComponent(url)).then((r) => {
                     if (!r.ok) throw new Error(r.status);
-                    return r.text();
+                    // Ensure the response is from our proxy function, not a SPA fallback to index.html
+                    if (!r.headers.get("x-proxy-success")) {
+                      throw new Error("Proxy response missing validation header");
+                    }
+                    return r.text().then((text) => {
+                      if (!looksLikeHtml(text)) throw new Error("Invalid HTML response");
+                      return text;
+                    });
                   })
               ]
             : []),
@@ -1827,18 +1847,27 @@
           () =>
             fetch(url).then((r) => {
               if (!r.ok) throw new Error(r.status);
-              return r.text();
+              return r.text().then((text) => {
+                if (!looksLikeHtml(text)) throw new Error("Invalid HTML response");
+                return text;
+              });
             }),
           /* 3. Public CORS proxies as last resort */
           () =>
             fetch("https://api.allorigins.win/raw?url=" + encodeURIComponent(url)).then((r) => {
               if (!r.ok) throw new Error(r.status);
-              return r.text();
+              return r.text().then((text) => {
+                if (!looksLikeHtml(text)) throw new Error("Invalid HTML response");
+                return text;
+              });
             }),
           () =>
             fetch("https://corsproxy.io/?" + encodeURIComponent(url)).then((r) => {
               if (!r.ok) throw new Error(r.status);
-              return r.text();
+              return r.text().then((text) => {
+                if (!looksLikeHtml(text)) throw new Error("Invalid HTML response");
+                return text;
+              });
             })
         ];
 


### PR DESCRIPTION
## What does this PR do?

Resolves a bug in the Open Graph Inspector where analyzing a URL would incorrectly fetch and display the One File Tools landing page metadata instead of the target URL's metadata. 

This happens because the Cloudflare Pages server-side proxy route (`/api/fetch`) did not exist, causing Cloudflare to fall back to serving `index.html` with a 200 OK status. 

To fix this, this PR:
1. Adds the missing Cloudflare Pages Function proxy (`functions/api/fetch.js`) to securely fetch external URLs and append an `X-Proxy-Success` validation header.
2. Updates the client-side `fetchPage` logic in `tools/open-graph-inspector.html` to verify the presence of this header, preventing false-positive successes and ensuring it falls back correctly to public CORS proxies when the proxy is unavailable (e.g. during local development).
3. Introduces a `looksLikeHtml` sanity check to all fetch attempts, ensuring non-HTML or error JSON responses from public proxies are correctly rejected and handled.

Closes #4

## Type of Change

<!-- Check the one that applies. -->

- [ ] New tool
- [ ] Enhancement to existing tool
- [x] Bug fix
- [ ] Documentation update
- [ ] Build system / infrastructure

## Screenshot

<!-- Required for new tools and UI changes. Drag and drop an image here. -->
*(No UI changes)*

## Checklist

<!-- Check all that apply before requesting review. -->

- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser

### For new tools:

- [ ] The tool is a single self-contained `.html` file in the `tools/` folder
- [ ] The filename is kebab-case (e.g. `json-formatter.html`)
- [ ] I added an entry to `tools.json` with all required fields
- [ ] I added a screenshot as `tools/<tool-name>.png` next to the HTML file
- [ ] The tool works offline (no external API calls required for core functionality)
- [ ] No external JS/CSS frameworks or CDN imports (Google Fonts are okay)
- [ ] I ran `node build.js` and verified the landing page renders correctly

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file