### PR TITLE
Improve empty-state UX when filters return zero tools

### DIFF
--- a/build.js
+++ b/build.js
@@ -239,7 +239,11 @@ function buildDesign1() {
       <div class="results-count"></div>
       <div class="d1-grid tool-grid">${cards}
       </div>
-      <div class="no-results">No tools found matching your search.</div>
+      <div class="no-results">
+        <h3>No tools available for the selected category.</h3>
+        <p>The current filters returned no results.</p>
+        <button type="button">Clear Filters</button>
+      </div>
       ${sharedFooter()}
     </section>`;
 }
@@ -630,7 +634,46 @@ const html = `<!DOCTYPE html>
       .tool-card-thumb { width: 100%; height: 180px; object-fit: cover; background: var(--bg-card-hover); display: block; }
       .tool-card-thumb-placeholder { width: 100%; height: 180px; background: var(--bg-card-hover); display: flex; align-items: center; justify-content: center; font-size: 2.5rem; color: var(--text-muted); user-select: none; }
 
-      .no-results { text-align: center; padding: 3rem 1rem; color: var(--text-muted); font-size: 1rem; display: none; }
+      .no-results {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: var(--text-muted);
+        display: none;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        max-width: 500px;
+        margin: 2rem auto;
+      }
+      .no-results h3 {
+        color: var(--text);
+        font-size: 1.2rem;
+        font-weight: 700;
+      }
+      .no-results p {
+        color: var(--text-muted);
+        font-size: 0.9rem;
+        margin-bottom: 0.5rem;
+      }
+      .no-results button {
+        font-family: var(--font);
+        font-size: 0.85rem;
+        font-weight: 600;
+        padding: 0.5rem 1.25rem;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: var(--accent);
+        color: #fff;
+        cursor: pointer;
+        transition: background var(--transition);
+      }
+      .no-results button:hover {
+        background: var(--accent-hover);
+      }
       .results-count { text-align: center; font-size: 0.8rem; color: var(--text-muted); margin: 0.5rem 0; }
 
       .site-footer { text-align: center; padding: 2rem 1.5rem; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.83rem; }
@@ -931,9 +974,25 @@ const html = `<!DOCTYPE html>
             c.style.display = show ? "" : "none";
             if (show) vis++;
           });
-          noResults.style.display = vis === 0 ? "block" : "none";
+          noResults.style.display = vis === 0 ? "flex" : "none";
           var hasFilter = q || activeCat !== "all" || activeTag;
           countEl.textContent = hasFilter ? vis + " tool" + (vis !== 1 ? "s" : "") + " found" : "";
+        }
+
+        var showAllBtn = noResults.querySelector("button");
+        if (showAllBtn) {
+          showAllBtn.addEventListener("click", function() {
+            input.value = "";
+            activeCat = "all";
+            activeTag = "";
+            filterBtns.forEach(function(x) {
+              x.classList.toggle("active", x.dataset.category === "all");
+            });
+            tagBtns.forEach(function(x) {
+              x.classList.remove("active");
+            });
+            run();
+          });
         }
 
         input.addEventListener("input", run);

--- a/index.html
+++ b/index.html
@@ -158,7 +158,46 @@
       .tool-card-thumb { width: 100%; height: 180px; object-fit: cover; background: var(--bg-card-hover); display: block; }
       .tool-card-thumb-placeholder { width: 100%; height: 180px; background: var(--bg-card-hover); display: flex; align-items: center; justify-content: center; font-size: 2.5rem; color: var(--text-muted); user-select: none; }
 
-      .no-results { text-align: center; padding: 3rem 1rem; color: var(--text-muted); font-size: 1rem; display: none; }
+      .no-results {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: var(--text-muted);
+        display: none;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        max-width: 500px;
+        margin: 2rem auto;
+      }
+      .no-results h3 {
+        color: var(--text);
+        font-size: 1.2rem;
+        font-weight: 700;
+      }
+      .no-results p {
+        color: var(--text-muted);
+        font-size: 0.9rem;
+        margin-bottom: 0.5rem;
+      }
+      .no-results button {
+        font-family: var(--font);
+        font-size: 0.85rem;
+        font-weight: 600;
+        padding: 0.5rem 1.25rem;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: var(--accent);
+        color: #fff;
+        cursor: pointer;
+        transition: background var(--transition);
+      }
+      .no-results button:hover {
+        background: var(--accent-hover);
+      }
       .results-count { text-align: center; font-size: 0.8rem; color: var(--text-muted); margin: 0.5rem 0; }
 
       .site-footer { text-align: center; padding: 2rem 1.5rem; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.83rem; }
@@ -468,7 +507,11 @@
           </div>
         </div>
       </div>
-      <div class="no-results">No tools found matching your search.</div>
+      <div class="no-results">
+        <h3>No tools available for the selected category.</h3>
+        <p>The current filters returned no results.</p>
+        <button type="button">Clear Filters</button>
+      </div>
       
       <footer class="site-footer">
         <div class="footer-links">
@@ -843,9 +886,25 @@
             c.style.display = show ? "" : "none";
             if (show) vis++;
           });
-          noResults.style.display = vis === 0 ? "block" : "none";
+          noResults.style.display = vis === 0 ? "flex" : "none";
           var hasFilter = q || activeCat !== "all" || activeTag;
           countEl.textContent = hasFilter ? vis + " tool" + (vis !== 1 ? "s" : "") + " found" : "";
+        }
+
+        var showAllBtn = noResults.querySelector("button");
+        if (showAllBtn) {
+          showAllBtn.addEventListener("click", function() {
+            input.value = "";
+            activeCat = "all";
+            activeTag = "";
+            filterBtns.forEach(function(x) {
+              x.classList.toggle("active", x.dataset.category === "all");
+            });
+            tagBtns.forEach(function(x) {
+              x.classList.remove("active");
+            });
+            run();
+          });
         }
 
         input.addEventListener("input", run);


### PR DESCRIPTION
Fixes #25 

## Summary

This PR improves the user experience when category filters or search queries return zero matching tools.

### Changes Made

* Replaced the generic empty-state message with a more informative UI.
* Added contextual messaging explaining why no tools are currently displayed.
* Added a "Clear Filters" action to help users quickly recover from an empty state.
* Updated generated `index.html` through the existing build process.

### Testing

* Tested category filters with no matching tools.
* Tested search queries with no matching tools.
* Verified that the Clear Filters button resets all active filters and restores the tool list.
* Successfully ran `npm run build`.
