### PR TITLE
added resume/portfolio preview wrapper

### DIFF
--- a/build.js
+++ b/build.js
@@ -1141,6 +1141,252 @@ if (profile) {
 
   function isoDate(d) { return d ? String(d) : ""; }
 
+// __ New: Preview Wrapper __   
+
+  function buildPreviewWrapper(type) {
+    // type is "portfolio" or "resume" — used for the back-link label and
+    // the title shown in the bar.
+    const labelMap = { portfolio: "Portfolio Themes", resume: "Resume Themes" };
+    const label = labelMap[type] || "Themes";
+ 
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Preview — One File Tools</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+ 
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #0d1117;
+    color: #e6edf3;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+ 
+  /* ── Top utility bar ── */
+  .preview-bar {
+    flex-shrink: 0;
+    height: 48px;
+    background: #161b22;
+    border-bottom: 1px solid #30363d;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 1rem;
+    z-index: 100;
+  }
+ 
+  .preview-bar .back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #8b949e;
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    white-space: nowrap;
+  }
+  .preview-bar .back-btn:hover {
+    color: #e6edf3;
+    border-color: #58a6ff;
+    background: #1c2333;
+    text-decoration: none;
+  }
+  .preview-bar .back-btn svg { flex-shrink: 0; }
+ 
+  .preview-bar .divider {
+    width: 1px;
+    height: 20px;
+    background: #30363d;
+    flex-shrink: 0;
+  }
+ 
+  .preview-bar .file-label {
+    font-size: 0.8rem;
+    color: #8b949e;
+    font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+  .preview-bar .file-label span {
+    color: #3fb950;
+  }
+ 
+  .preview-bar .open-raw-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #e6edf3;
+    text-decoration: none;
+    padding: 0.35rem 0.85rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: #21262d;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .preview-bar .open-raw-btn:hover {
+    border-color: #58a6ff;
+    background: #1c2333;
+    text-decoration: none;
+  }
+  .preview-bar .open-raw-btn svg { flex-shrink: 0; }
+ 
+  /* ── Iframe fills remaining viewport ── */
+  .preview-frame {
+    flex: 1;
+    width: 100%;
+    border: none;
+    display: block;
+    background: #fff;
+  }
+ 
+  /* ── Error state shown when no ?file= is supplied ── */
+  .preview-error {
+    flex: 1;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    text-align: center;
+    padding: 2rem;
+    color: #8b949e;
+  }
+  .preview-error h2 { font-size: 1.2rem; color: #e6edf3; }
+  .preview-error p { font-size: 0.9rem; max-width: 420px; }
+  .preview-error a {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 0.5rem 1.2rem;
+    background: #238636;
+    color: #fff;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .preview-error a:hover { background: #2ea043; }
+</style>
+</head>
+<body>
+ 
+<nav class="preview-bar" id="previewBar">
+  <!-- Back button -->
+  <a href="index.html" class="back-btn" id="backBtn" title="Exit preview and return to ${label}">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="15 18 9 12 15 6"/>
+    </svg>
+    Exit Preview
+  </a>
+ 
+  <div class="divider"></div>
+ 
+  <!-- Current file path label -->
+  <div class="file-label" id="fileLabel">
+    <span>&#9679;</span> Loading…
+  </div>
+ 
+  <!-- Open raw file in new tab -->
+  <a href="#" class="open-raw-btn" id="openRawBtn" target="_blank" rel="noopener noreferrer" title="Open the standalone HTML file in a new tab">
+    Open Raw File
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+      <polyline points="15 3 21 3 21 9"/>
+      <line x1="10" y1="14" x2="21" y2="3"/>
+    </svg>
+  </a>
+</nav>
+ 
+<iframe class="preview-frame" id="previewFrame" title="Theme preview" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
+ 
+<div class="preview-error" id="previewError">
+  <h2>No theme specified</h2>
+  <p>This page expects a <code>?file=</code> query parameter pointing to a theme file, e.g. <code>preview.html?file=themes/classic.html</code></p>
+  <a href="index.html">&larr; Back to ${label}</a>
+</div>
+ 
+<script>
+(function () {
+  "use strict";
+ 
+  var frame   = document.getElementById("previewFrame");
+  var errorEl = document.getElementById("previewError");
+  var labelEl = document.getElementById("fileLabel");
+  var rawBtn  = document.getElementById("openRawBtn");
+ 
+  // Parse the ?file= parameter from the current URL.
+  // We intentionally do NOT use URLSearchParams for maximum browser compat.
+  function getParam(name) {
+    var search = window.location.search.slice(1);
+    var pairs  = search.split("&");
+    for (var i = 0; i < pairs.length; i++) {
+      var idx = pairs[i].indexOf("=");
+      if (idx === -1) continue;
+      var key = decodeURIComponent(pairs[i].slice(0, idx));
+      if (key === name) {
+        return decodeURIComponent(pairs[i].slice(idx + 1).replace(/\\+/g, " "));
+      }
+    }
+    return null;
+  }
+ 
+  // Security: reject paths that try to escape the current directory.
+  // Only bare filenames and single-level relative paths (e.g. themes/foo.html)
+  // are allowed — no leading slashes, no protocol schemes, no ".." segments.
+  function isSafePath(p) {
+    if (!p) return false;
+    if (/^[a-zA-Z][a-zA-Z0-9+\\-.]*:\\/\\//.test(p)) return false; // absolute URL
+    if (p.charAt(0) === "/")                            return false; // absolute path
+    if (/(^|\\/)\\.\\.(\\/|$)/.test(p))                  return false; // directory traversal
+    return true;
+  }
+ 
+  var file = getParam("file");
+ 
+  if (!file || !isSafePath(file)) {
+    // No valid file param — show the error state, hide the iframe.
+    frame.style.display   = "none";
+    errorEl.style.display = "flex";
+    labelEl.innerHTML     = "<span style=\\"color:#f85149\\">&times;</span> No file specified";
+    rawBtn.style.display  = "none";
+    return;
+  }
+ 
+  // Show the file path in the bar (just the filename part for brevity).
+  var displayName = file.split("/").pop();
+  labelEl.innerHTML = "<span>&#9679;</span> " + displayName;
+ 
+  // Point the "Open Raw File" button at the same file.
+  rawBtn.href = file;
+ 
+  // Load the theme into the iframe.
+  frame.src = file;
+})();
+</script>
+ 
+</body>
+</html>`;
+  }
+
   // ── Resume theme: Classic ──
 
   function buildResumeClassic(profile) {
@@ -1896,8 +2142,8 @@ ${has(talks) || has(publications) ? `<section id="talks-publications"><div class
             <h3>Classic</h3>
             <p>Traditional single-column layout. Conservative, corporate-safe. Clean typography with clear section hierarchy.</p>
             <div class="theme-links">
-              <a href="themes/classic.html" class="btn-primary">Preview</a>
-              <a href="themes/classic.html" class="btn-outline" onclick="window.open(this.href);setTimeout(function(){window.open(this.href).print()},500);return false;">Print</a>
+              <a href="preview.html?file=themes/classic.html" class="btn-primary">Preview</a>
+              <a href="themes/classic.html" class="btn-outline" target="_blank" rel="noopener noreferrer">Open Raw</a>
             </div>
           </div>
         </div>
@@ -1976,7 +2222,8 @@ ${has(talks) || has(publications) ? `<section id="talks-publications"><div class
             <h3>Developer</h3>
             <p>Terminal/IDE aesthetic with monospace fonts, dark by default. Code-focused with syntax-highlight color accents.</p>
             <div class="theme-links">
-              <a href="themes/developer.html" class="btn-primary">Preview</a>
+              <a href="preview.html?file=themes/developer.html" class="btn-primary">Preview</a>
+              <a href="themes/developer.html" class="btn-outline" target="_blank" rel="noopener noreferrer">Open Raw</a>
             </div>
           </div>
         </div>
@@ -2010,6 +2257,12 @@ ${has(talks) || has(publications) ? `<section id="talks-publications"><div class
   console.log("Built resume/index.html");
   console.log("Built portfolio/index.html");
 
+ // Write preview wrapper pages for resume and portfolio
+  fs.writeFileSync(path.join(__dirname, "resume", "preview.html"), buildPreviewWrapper("resume"), "utf-8");
+  fs.writeFileSync(path.join(__dirname, "portfolio", "preview.html"), buildPreviewWrapper("portfolio"), "utf-8");
+  console.log("Built resume/preview.html");
+  console.log("Built portfolio/preview.html");
+ 
 } else {
   console.log("\nSkipping resume/portfolio generation (no profile.json found).");
 }

--- a/portfolio/preview.html
+++ b/portfolio/preview.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Preview — One File Tools</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+ 
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #0d1117;
+    color: #e6edf3;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+ 
+  /* ── Top utility bar ── */
+  .preview-bar {
+    flex-shrink: 0;
+    height: 48px;
+    background: #161b22;
+    border-bottom: 1px solid #30363d;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 1rem;
+    z-index: 100;
+  }
+ 
+  .preview-bar .back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #8b949e;
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    white-space: nowrap;
+  }
+  .preview-bar .back-btn:hover {
+    color: #e6edf3;
+    border-color: #58a6ff;
+    background: #1c2333;
+    text-decoration: none;
+  }
+  .preview-bar .back-btn svg { flex-shrink: 0; }
+ 
+  .preview-bar .divider {
+    width: 1px;
+    height: 20px;
+    background: #30363d;
+    flex-shrink: 0;
+  }
+ 
+  .preview-bar .file-label {
+    font-size: 0.8rem;
+    color: #8b949e;
+    font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+  .preview-bar .file-label span {
+    color: #3fb950;
+  }
+ 
+  .preview-bar .open-raw-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #e6edf3;
+    text-decoration: none;
+    padding: 0.35rem 0.85rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: #21262d;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .preview-bar .open-raw-btn:hover {
+    border-color: #58a6ff;
+    background: #1c2333;
+    text-decoration: none;
+  }
+  .preview-bar .open-raw-btn svg { flex-shrink: 0; }
+ 
+  /* ── Iframe fills remaining viewport ── */
+  .preview-frame {
+    flex: 1;
+    width: 100%;
+    border: none;
+    display: block;
+    background: #fff;
+  }
+ 
+  /* ── Error state shown when no ?file= is supplied ── */
+  .preview-error {
+    flex: 1;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    text-align: center;
+    padding: 2rem;
+    color: #8b949e;
+  }
+  .preview-error h2 { font-size: 1.2rem; color: #e6edf3; }
+  .preview-error p { font-size: 0.9rem; max-width: 420px; }
+  .preview-error a {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 0.5rem 1.2rem;
+    background: #238636;
+    color: #fff;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .preview-error a:hover { background: #2ea043; }
+</style>
+</head>
+<body>
+ 
+<nav class="preview-bar" id="previewBar">
+  <!-- Back button -->
+  <a href="index.html" class="back-btn" id="backBtn" title="Exit preview and return to Portfolio Themes">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="15 18 9 12 15 6"/>
+    </svg>
+    Exit Preview
+  </a>
+ 
+  <div class="divider"></div>
+ 
+  <!-- Current file path label -->
+  <div class="file-label" id="fileLabel">
+    <span>&#9679;</span> Loading…
+  </div>
+ 
+  <!-- Open raw file in new tab -->
+  <a href="#" class="open-raw-btn" id="openRawBtn" target="_blank" rel="noopener noreferrer" title="Open the standalone HTML file in a new tab">
+    Open Raw File
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+      <polyline points="15 3 21 3 21 9"/>
+      <line x1="10" y1="14" x2="21" y2="3"/>
+    </svg>
+  </a>
+</nav>
+ 
+<iframe class="preview-frame" id="previewFrame" title="Theme preview" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
+ 
+<div class="preview-error" id="previewError">
+  <h2>No theme specified</h2>
+  <p>This page expects a <code>?file=</code> query parameter pointing to a theme file, e.g. <code>preview.html?file=themes/classic.html</code></p>
+  <a href="index.html">&larr; Back to Portfolio Themes</a>
+</div>
+ 
+<script>
+(function () {
+  "use strict";
+ 
+  var frame   = document.getElementById("previewFrame");
+  var errorEl = document.getElementById("previewError");
+  var labelEl = document.getElementById("fileLabel");
+  var rawBtn  = document.getElementById("openRawBtn");
+ 
+  // Parse the ?file= parameter from the current URL.
+  // We intentionally do NOT use URLSearchParams for maximum browser compat.
+  function getParam(name) {
+    var search = window.location.search.slice(1);
+    var pairs  = search.split("&");
+    for (var i = 0; i < pairs.length; i++) {
+      var idx = pairs[i].indexOf("=");
+      if (idx === -1) continue;
+      var key = decodeURIComponent(pairs[i].slice(0, idx));
+      if (key === name) {
+        return decodeURIComponent(pairs[i].slice(idx + 1).replace(/\+/g, " "));
+      }
+    }
+    return null;
+  }
+ 
+  // Security: reject paths that try to escape the current directory.
+  // Only bare filenames and single-level relative paths (e.g. themes/foo.html)
+  // are allowed — no leading slashes, no protocol schemes, no ".." segments.
+  function isSafePath(p) {
+    if (!p) return false;
+    if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(p)) return false; // absolute URL
+    if (p.charAt(0) === "/")                            return false; // absolute path
+    if (/(^|\/)\.\.(\/|$)/.test(p))                  return false; // directory traversal
+    return true;
+  }
+ 
+  var file = getParam("file");
+ 
+  if (!file || !isSafePath(file)) {
+    // No valid file param — show the error state, hide the iframe.
+    frame.style.display   = "none";
+    errorEl.style.display = "flex";
+    labelEl.innerHTML     = "<span style=\"color:#f85149\">&times;</span> No file specified";
+    rawBtn.style.display  = "none";
+    return;
+  }
+ 
+  // Show the file path in the bar (just the filename part for brevity).
+  var displayName = file.split("/").pop();
+  labelEl.innerHTML = "<span>&#9679;</span> " + displayName;
+ 
+  // Point the "Open Raw File" button at the same file.
+  rawBtn.href = file;
+ 
+  // Load the theme into the iframe.
+  frame.src = file;
+})();
+</script>
+ 
+</body>
+</html>

--- a/resume/preview.html
+++ b/resume/preview.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Preview — One File Tools</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+ 
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #0d1117;
+    color: #e6edf3;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+ 
+  /* ── Top utility bar ── */
+  .preview-bar {
+    flex-shrink: 0;
+    height: 48px;
+    background: #161b22;
+    border-bottom: 1px solid #30363d;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 1rem;
+    z-index: 100;
+  }
+ 
+  .preview-bar .back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #8b949e;
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    white-space: nowrap;
+  }
+  .preview-bar .back-btn:hover {
+    color: #e6edf3;
+    border-color: #58a6ff;
+    background: #1c2333;
+    text-decoration: none;
+  }
+  .preview-bar .back-btn svg { flex-shrink: 0; }
+ 
+  .preview-bar .divider {
+    width: 1px;
+    height: 20px;
+    background: #30363d;
+    flex-shrink: 0;
+  }
+ 
+  .preview-bar .file-label {
+    font-size: 0.8rem;
+    color: #8b949e;
+    font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+  .preview-bar .file-label span {
+    color: #3fb950;
+  }
+ 
+  .preview-bar .open-raw-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #e6edf3;
+    text-decoration: none;
+    padding: 0.35rem 0.85rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: #21262d;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .preview-bar .open-raw-btn:hover {
+    border-color: #58a6ff;
+    background: #1c2333;
+    text-decoration: none;
+  }
+  .preview-bar .open-raw-btn svg { flex-shrink: 0; }
+ 
+  /* ── Iframe fills remaining viewport ── */
+  .preview-frame {
+    flex: 1;
+    width: 100%;
+    border: none;
+    display: block;
+    background: #fff;
+  }
+ 
+  /* ── Error state shown when no ?file= is supplied ── */
+  .preview-error {
+    flex: 1;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    text-align: center;
+    padding: 2rem;
+    color: #8b949e;
+  }
+  .preview-error h2 { font-size: 1.2rem; color: #e6edf3; }
+  .preview-error p { font-size: 0.9rem; max-width: 420px; }
+  .preview-error a {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 0.5rem 1.2rem;
+    background: #238636;
+    color: #fff;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .preview-error a:hover { background: #2ea043; }
+</style>
+</head>
+<body>
+ 
+<nav class="preview-bar" id="previewBar">
+  <!-- Back button -->
+  <a href="index.html" class="back-btn" id="backBtn" title="Exit preview and return to Resume Themes">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="15 18 9 12 15 6"/>
+    </svg>
+    Exit Preview
+  </a>
+ 
+  <div class="divider"></div>
+ 
+  <!-- Current file path label -->
+  <div class="file-label" id="fileLabel">
+    <span>&#9679;</span> Loading…
+  </div>
+ 
+  <!-- Open raw file in new tab -->
+  <a href="#" class="open-raw-btn" id="openRawBtn" target="_blank" rel="noopener noreferrer" title="Open the standalone HTML file in a new tab">
+    Open Raw File
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+      <polyline points="15 3 21 3 21 9"/>
+      <line x1="10" y1="14" x2="21" y2="3"/>
+    </svg>
+  </a>
+</nav>
+ 
+<iframe class="preview-frame" id="previewFrame" title="Theme preview" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
+ 
+<div class="preview-error" id="previewError">
+  <h2>No theme specified</h2>
+  <p>This page expects a <code>?file=</code> query parameter pointing to a theme file, e.g. <code>preview.html?file=themes/classic.html</code></p>
+  <a href="index.html">&larr; Back to Resume Themes</a>
+</div>
+ 
+<script>
+(function () {
+  "use strict";
+ 
+  var frame   = document.getElementById("previewFrame");
+  var errorEl = document.getElementById("previewError");
+  var labelEl = document.getElementById("fileLabel");
+  var rawBtn  = document.getElementById("openRawBtn");
+ 
+  // Parse the ?file= parameter from the current URL.
+  // We intentionally do NOT use URLSearchParams for maximum browser compat.
+  function getParam(name) {
+    var search = window.location.search.slice(1);
+    var pairs  = search.split("&");
+    for (var i = 0; i < pairs.length; i++) {
+      var idx = pairs[i].indexOf("=");
+      if (idx === -1) continue;
+      var key = decodeURIComponent(pairs[i].slice(0, idx));
+      if (key === name) {
+        return decodeURIComponent(pairs[i].slice(idx + 1).replace(/\+/g, " "));
+      }
+    }
+    return null;
+  }
+ 
+  // Security: reject paths that try to escape the current directory.
+  // Only bare filenames and single-level relative paths (e.g. themes/foo.html)
+  // are allowed — no leading slashes, no protocol schemes, no ".." segments.
+  function isSafePath(p) {
+    if (!p) return false;
+    if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(p)) return false; // absolute URL
+    if (p.charAt(0) === "/")                            return false; // absolute path
+    if (/(^|\/)\.\.(\/|$)/.test(p))                  return false; // directory traversal
+    return true;
+  }
+ 
+  var file = getParam("file");
+ 
+  if (!file || !isSafePath(file)) {
+    // No valid file param — show the error state, hide the iframe.
+    frame.style.display   = "none";
+    errorEl.style.display = "flex";
+    labelEl.innerHTML     = "<span style=\"color:#f85149\">&times;</span> No file specified";
+    rawBtn.style.display  = "none";
+    return;
+  }
+ 
+  // Show the file path in the bar (just the filename part for brevity).
+  var displayName = file.split("/").pop();
+  labelEl.innerHTML = "<span>&#9679;</span> " + displayName;
+ 
+  // Point the "Open Raw File" button at the same file.
+  rawBtn.href = file;
+ 
+  // Load the theme into the iframe.
+  frame.src = file;
+})();
+</script>
+ 
+</body>
+</html>


### PR DESCRIPTION
## What does this PR do?

Adds a preview wrapper for resume and portfolio templates that provides a better preview experience without modifying the standalone templates themselves.

The preview now includes controls such as:
- Exit Preview (returns to the gallery)
- Open in New Window

This keeps the generated templates completely standalone while making navigation back to One File Tools much smoother.

Closes #79 

## Type of Change

<!-- Check the one that applies. -->

- [ ] New tool
- [x] Enhancement to existing tool
- [ ] Bug fix
- [ ] Documentation update
- [x] Build system / infrastructure

## Screenshot

<img width="1892" height="862" alt="image" src="https://github.com/user-attachments/assets/ee52eabb-f1dc-4db6-aba2-91c70c2e6838" />
<img width="1900" height="202" alt="image" src="https://github.com/user-attachments/assets/14a557fd-542c-4fc4-a8d2-db6b61465fe3" />

## Checklist

<!-- Check all that apply before requesting review. -->

- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser

### For new tools:

- [ ] The tool is a single self-contained `.html` file in the `tools/` folder
- [ ] The filename is kebab-case (e.g. `json-formatter.html`)
- [ ] I added an entry to `tools.json` with all required fields
- [ ] I added a screenshot as `tools/<tool-name>.png` next to the HTML file
- [ ] The tool works offline (no external API calls required for core functionality)
- [ ] No external JS/CSS frameworks or CDN imports (Google Fonts are okay)
- [ ] I ran `node sort-norm.js tools.json` to sort and normalize the tools registry
- [ ] I ran `node build.js` and verified the landing page renders correctly

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file