### PR TITLE
Feat: Add in-app back button for connected pages

### DIFF
--- a/assets/css/previewBar.css
+++ b/assets/css/previewBar.css
@@ -1,0 +1,62 @@
+/* Preview Bar */
+
+.preview-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+
+    height: 54px;
+
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+
+    padding: 0 20px;
+
+    background: #242424;
+    color: #fff;
+
+    border-bottom: 1px solid #3a3a3a;
+    box-shadow: 0 1px 4px rgba(0,0,0,.2);
+
+    z-index: 9999;
+}
+
+.preview-back {
+    justify-self: start;
+
+    background: none;
+    border: none;
+
+    color: #fff;
+
+    cursor: pointer;
+
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.preview-back:hover {
+    opacity: .8;
+}
+
+.preview-brand {
+    justify-self: center;
+
+    font-size: 15px;
+    font-weight: 600;
+}
+
+.preview-github {
+    justify-self: end;
+
+    color: white;
+    text-decoration: none;
+
+    font-size: 14px;
+}
+
+.preview-github:hover {
+    text-decoration: underline;
+}

--- a/assets/js/previewBar.js
+++ b/assets/js/previewBar.js
@@ -1,0 +1,40 @@
+const fallback = document.body.dataset.fallback || "../../index.html";
+
+document.body.classList.add("has-preview-bar");
+
+document.body.insertAdjacentHTML(
+  "afterbegin",
+  `
+<div class="preview-bar">
+
+    <button class="preview-back">
+        ← Back
+    </button>
+
+    <div class="preview-brand">
+        One File Tools
+    </div>
+
+    <a
+        class="preview-github"
+        href="https://github.com/praveenscience/One-File-Tools"
+        target="_blank"
+        rel="noopener noreferrer">
+
+        GitHub ↗
+
+    </a>
+
+</div>
+`
+);
+
+document
+  .querySelector(".preview-back")
+  .addEventListener("click", () => {
+    if (window.history.length > 1 && document.referrer) {
+      history.back();
+    } else {
+      window.location.href = fallback;
+    }
+  });

--- a/portfolio/themes/developer.html
+++ b/portfolio/themes/developer.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Jane Doe — Senior Full Stack Developer</title>
+<link rel="stylesheet" href="../../assets/css/previewBar.css">
 <meta name="description" content="Building scalable web applications with modern JavaScript">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -40,7 +41,26 @@ a{color:var(--accent-blue);text-decoration:none;transition:color var(--transitio
 a:hover{color:var(--accent-cyan)}
 ::selection{background:var(--accent-blue);color:#fff}
 
-.nav{position:fixed;top:0;left:0;right:0;z-index:1000;height:var(--nav-h);background:var(--bg-nav);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:center}
+.nav{
+    position:fixed;
+    top:0;
+    left:0;
+    right:0;
+    z-index:1000;
+    height:var(--nav-h);
+    background:var(--bg-nav);
+    backdrop-filter:blur(12px);
+    -webkit-backdrop-filter:blur(12px);
+    border-bottom:1px solid var(--border);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+}
+
+/* When preview bar is present */
+body.has-preview-bar .nav{
+    top:54px;
+}
 .nav-inner{width:100%;max-width:var(--max-w);padding:0 1.5rem;display:flex;align-items:center;justify-content:space-between}
 .nav-logo{font-weight:700;font-size:.95rem;color:var(--accent-green);white-space:nowrap}
 .nav-logo .prompt{color:var(--accent-yellow)}
@@ -172,7 +192,7 @@ footer a{color:var(--accent-blue)}
 @media(max-width:600px){section{padding:3rem 1rem 2rem}.projects-grid,.talks-grid{grid-template-columns:1fr}.timeline{padding-left:1.5rem}.timeline-item{padding-left:1rem}}
 </style>
 </head>
-<body>
+<body data-fallback="../index.html">
 <nav class="nav" role="navigation" aria-label="Main navigation">
   <div class="nav-inner">
     <div class="nav-logo"><span class="prompt">&gt;</span> jane_doe <span style="color:var(--comment)">--role</span> <span style="color:var(--string)">"Senior Full Stack Developer"</span></div>
@@ -432,6 +452,7 @@ footer a{color:var(--accent-blue)}
 
 <button class="back-to-top" id="backToTop" aria-label="Back to top"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></button>
 
+<script src="../../assets/js/previewBar.js"></script>
 <script>
 (function(){
   "use strict";

--- a/resume/themes/classic.html
+++ b/resume/themes/classic.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Jane Doe — Resume</title>
+  <link rel="stylesheet" href="../../assets/css/previewBar.css">
 <style>
 @page { size: A4; margin: 15mm 20mm; }
 
@@ -96,7 +97,7 @@ li { font-size: 10pt; color: #333; margin-bottom: 2px; }
 }
 </style>
 </head>
-<body>
+<body data-fallback="../index.html">
 <div class="page">
 
 <header>
@@ -234,5 +235,6 @@ li { font-size: 10pt; color: #333; margin-bottom: 2px; }
 <footer style="text-align:center;padding:1.5rem;font-size:8pt;color:#999;border-top:1px solid #e5e7eb;margin-top:1rem">
   <p>Built with <a href="https://github.com/praveenscience/One-File-Tools" style="color:#2563eb;text-decoration:none">One File Tools</a></p>
 </footer>
+<script src="../../assets/js/previewBar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## What does this PR do?

## Description

- Added a reusable preview bar component for preview pages.
- Included a **Back** button that navigates to the previous page using browser history, with a fallback to the appropriate index page when no history is available.
- Added a centered **One File Tools** branding section and a **GitHub** link to match the preview experience.
- Integrated the preview bar into resume and portfolio preview pages without introducing any external dependencies.
- Adjusted the layout of pages with fixed navigation so the preview bar and page navigation remain accessible.

Closes #79

## Type of Change

- [ ] New tool
- [x] Enhancement to existing tool
- [ ] Bug fix
- [ ] Documentation update
- [ ] Build system / infrastructure

## Screenshot

<img width="3584" height="470" alt="image" src="https://github.com/user-attachments/assets/57eb99ac-3682-4dd4-8499-5037be0acd1c" />
<img width="3584" height="470" alt="image" src="https://github.com/user-attachments/assets/35fad25e-7cc7-4322-936e-a401e82cbace" />


## Checklist

- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file
