### PR TITLE
Enhance: add Quests pillar infrastructure

### DIFF
--- a/data/quests.json
+++ b/data/quests.json
@@ -1,0 +1,23 @@
+{
+  "categories": [
+    {
+      "id": "css-fundamentals",
+      "name": "CSS Fundamentals",
+      "icon": "🎨",
+      "description": "Box model, specificity, flexbox, and grid, learned by doing"
+    },
+    {
+      "id": "git",
+      "name": "Git & Version Control",
+      "icon": "🔀",
+      "description": "Branching, rebasing, and Git workflows explained interactively"
+    },
+    {
+      "id": "js-fundamentals",
+      "name": "JavaScript Fundamentals",
+      "icon": "⚙️",
+      "description": "Closures, async, and core JS concepts through interactive challenges"
+    }
+  ],
+  "quests": []
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "themes": "node scripts/theme-gen.js",
-    "sort": "node scripts/sort-norm.js data/tools.json && node scripts/sort-norm.js data/themes.json",
+    "sort": "node scripts/sort-norm.js data/tools.json && node scripts/sort-norm.js data/themes.json && node scripts/sort-norm.js data/quests.json",
     "sync-readme": "node scripts/sync-readme.js",
     "format": "prettier --write tools/*.html"
   },

--- a/quests/Contributing.md
+++ b/quests/Contributing.md
@@ -1,0 +1,136 @@
+# Contributing a Quest
+
+Thank you for contributing a quest to One File Tools! Quests are interactive, gamified lessons — think of them as playable tutorials, not one-shot utilities. This guide mirrors the [tools Contributing guide](../tools/Contributing.md), adjusted for quests.
+
+---
+
+## What you're building
+
+A **single, self-contained HTML file** that teaches something through interaction — a Git branching simulator, a CSS specificity challenge, a JS closures puzzle. Same rules as tools: everything in one file, no build step, no frameworks. Progress is saved locally using `localStorage`, not a server.
+
+### Example
+
+```
+quests/git-basics.html    <- your quest (one file, everything inside)
+quests/git-basics.png     <- screenshot of your quest
+```
+
+---
+
+## Before you start
+
+1. Check [existing quests](../ReadMe.md) so you don't duplicate one
+2. Open an [issue](https://github.com/praveenscience/One-File-Tools/issues) or comment on an existing one to claim it
+3. **Wait for assignment** before starting
+4. Look at existing tools in `tools/` for the coding conventions this repo follows
+
+---
+
+## Step-by-step guide
+
+### 1. Fork, clone, and install
+
+```bash
+git clone https://github.com/YOUR-USERNAME/One-File-Tools.git
+cd One-File-Tools
+npm install
+```
+
+### 2. Create a branch
+
+```bash
+git checkout -b add/quest-name
+```
+
+### 3. Create your file
+
+Use kebab-case, matching your quest's `id`:
+
+```bash
+touch quests/git-basics.html
+```
+
+### 4. Build your quest
+
+Same starter conventions as tools: semantic HTML, CSS custom properties for theming, dark mode support, vanilla JS. Use `localStorage` to persist progress between visits — see `tools/code-snippet-manager.html` for a reference on local storage usage in this repo.
+
+### 5. Register your quest in data/quests.json
+
+Open `data/quests.json` and add an entry to the `"quests"` array:
+
+```json
+{
+  "id": "git-basics",
+  "name": "Git Basics",
+  "shortDescription": "Learn the core Git workflow by making commits and branches interactively.",
+  "longDescription": "## Git Basics\n\nAn interactive quest teaching the fundamental Git workflow.\n\n### Features\n\n- Step-by-step guided challenges\n- Progress saved locally",
+  "category": "git",
+  "tags": ["git", "beginner", "interactive"],
+  "techStack": ["HTML5", "CSS3", "Vanilla JS", "LocalStorage API"],
+  "difficulty": "Easy",
+  "status": "live"
+}
+```
+
+#### Field reference
+
+Identical to `tools/Contributing.md`'s field reference — `id`, `name`, `shortDescription`, `longDescription`, `category`, `tags`, `techStack`, `difficulty`, `status` all mean the same thing here.
+
+#### Valid category IDs
+
+| ID | Display name |
+|----|-------------|
+| `git` | Git & Version Control |
+| `css-fundamentals` | CSS Fundamentals |
+| `js-fundamentals` | JavaScript Fundamentals |
+
+If your quest doesn't fit an existing category, propose a new one in your issue first.
+
+### 6. Add a screenshot
+
+Same as tools: `quests/your-quest-name.png`, 1280x720 recommended, showing the quest mid-interaction, not an empty state.
+
+### 7. Sort and normalize
+
+```bash
+node scripts/sort-norm.js data/quests.json
+```
+
+### 8. Build and verify
+
+```bash
+node scripts/build.js
+open index.html
+```
+
+Click the Quests pillar and confirm your quest card appears correctly.
+
+### 9. Test thoroughly
+
+Same checklist as tools: Chrome + Firefox, mobile responsive, no console errors, keyboard accessible, edge cases handled — plus specifically verify your progress-tracking actually persists across a page reload.
+
+### 10. Format, commit, push
+
+```bash
+npm run format
+git add quests/your-quest-name.html quests/your-quest-name.png data/quests.json
+git commit -m "Add: your-quest-name"
+git push origin add/quest-name
+```
+
+Then open a Pull Request.
+
+---
+
+## Quest requirements
+
+Same **Must have / Should have / Must not have** rules as `tools/Contributing.md`, with one addition:
+
+- **Must persist progress** via `localStorage` so a learner doesn't lose their place on refresh
+- **Must have a clear "start" and "complete" state** — the learner should always know where they are in the quest
+
+---
+
+## PR format
+
+Same as tools: `Add: quest-name`, link the issue with `Closes #123`, include a screenshot, confirm the checklist.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,6 +25,12 @@ const rootDir = path.join(__dirname, "..");
 const data = JSON.parse(fs.readFileSync(path.join(rootDir, "data", "tools.json"), "utf-8"));
 const { site, categories, tools } = data;
 
+// Quests registry is optional — build should not fail if it doesn't exist yet.
+const questsPath = path.join(rootDir, "data", "quests.json");
+const questsDataRaw = fs.existsSync(questsPath) ? JSON.parse(fs.readFileSync(questsPath, "utf-8")) : { categories: [], quests: [] };
+const questCategories = questsDataRaw.categories || [];
+const quests = questsDataRaw.quests || [];
+
 // ──────────────────────────────────────────────
 // Helpers
 // ──────────────────────────────────────────────
@@ -138,6 +144,10 @@ function thumbnailExists(toolId) {
   return fs.existsSync(path.join(rootDir, "tools", toolId + ".png"));
 }
 
+function questThumbnailExists(questId) {
+  return fs.existsSync(path.join(rootDir, "quests", questId + ".png"));
+}
+
 // ──────────────────────────────────────────────
 // Build tool data
 // ──────────────────────────────────────────────
@@ -179,6 +189,40 @@ const totalCount = tools.length;
 const allTags = [...new Set(tools.flatMap((t) => t.tags || []))].sort();
 
 // ──────────────────────────────────────────────
+// Build quest data
+// ──────────────────────────────────────────────
+
+const questCategoryMap = {};
+questCategories.forEach((c) => {
+  questCategoryMap[c.id] = c;
+});
+
+const questsDataBuilt = quests.map((q) => ({
+  id: q.id,
+  name: q.name,
+  shortDescription: q.shortDescription,
+  longDescriptionHtml: markdownToHtml(q.longDescription),
+  category: q.category,
+  categoryName: questCategoryMap[q.category]?.name || q.category,
+  categoryIcon: questCategoryMap[q.category]?.icon || "",
+  tags: q.tags || [],
+  techStack: q.techStack || [],
+  difficulty: q.difficulty || "Easy",
+  status: q.status || "idea",
+  hasThumbnail: questThumbnailExists(q.id),
+  file: `quests/${q.id}.html`,
+  thumbnail: `quests/${q.id}.png`,
+  github: `${site.github}/blob/main/quests/${q.id}.html`,
+  live: `${site.url}/quests/${q.id}`
+}));
+
+const totalQuestCount = questsDataBuilt.length;
+
+const questCountByCategory = {};
+questCategories.forEach((c) => { questCountByCategory[c.id] = 0; });
+questsDataBuilt.forEach((q) => { if (questCountByCategory[q.category] !== undefined) questCountByCategory[q.category]++; });
+
+// ──────────────────────────────────────────────
 // Template-based index.html generation
 // ──────────────────────────────────────────────
 
@@ -218,6 +262,13 @@ function buildPillarCards() {
       count: portfolioThemes.length + " theme" + (portfolioThemes.length === 1 ? "" : "s"),
       desc: "Developer portfolio themes from a single JSON file. Dark/light, responsive.",
       icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M7 6.5h.01M10 6.5h.01"/></svg>'
+    },
+    {
+      id: "quests",
+      title: "One File Quests",
+      count: totalQuestCount + " quest" + (totalQuestCount === 1 ? "" : "s"),
+      desc: "Interactive, gamified lessons to learn Git, CSS, and JS by doing.",
+      icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.4 6.6L21 11l-6.6 2.4L12 20l-2.4-6.6L3 11l6.6-2.4z"/></svg>'
     },
     {
       id: "soon",
@@ -287,6 +338,47 @@ function buildToolCards() {
   }).join("\n");
 }
 
+// ── Build quest filter pills (static HTML) ──
+
+function buildQuestFilterPills() {
+  const pills = ['              <button class="pill" type="button" data-cat="all" aria-pressed="true"><span class="pi" aria-hidden="true">\u25A6</span> All <span class="pill-count">(' + totalQuestCount + ')</span></button>'];
+  questCategories.forEach((c) => {
+    const count = questCountByCategory[c.id] || 0;
+    if (count === 0) return;
+    pills.push('              <button class="pill" type="button" data-cat="' + escapeAttr(c.id) + '" aria-pressed="false"><span class="pi" aria-hidden="true">' + c.icon + '</span> ' + escapeHtml(c.name) + ' <span class="pill-count">(' + count + ')</span></button>');
+  });
+  return pills.join("\n");
+}
+
+// ── Build quest cards (static HTML) ──
+
+function buildQuestCards() {
+  return questsDataBuilt.map((q) => {
+    const cat = questCategoryMap[q.category];
+    const diff = q.difficulty.toLowerCase();
+    const searchData = (q.name + " " + q.shortDescription + " " + q.tags.join(" ")).toLowerCase();
+    const liveUrl = site.url + "/quests/" + q.id;
+
+    const thumbHtml = q.hasThumbnail
+      ? '<img class="card-thumb" src="quests/' + escapeAttr(q.id) + '.png" alt="' + escapeAttr(q.name) + '" loading="lazy" />'
+      : '<div class="card-thumb-placeholder">' + (cat ? cat.icon : '') + '</div>';
+
+    return '            <article class="card" data-id="' + escapeAttr(q.id) + '" data-category="' + escapeAttr(q.category) + '" data-search="' + escapeAttr(searchData) + '" tabindex="0" role="button" aria-label="View details for ' + escapeAttr(q.name) + '">' +
+      thumbHtml +
+      '<div class="card-body">' +
+      '<div class="card-top"><h4>' + escapeHtml(q.name) + '</h4>' +
+      '<span class="badge-cat"><span aria-hidden="true">' + (cat ? cat.icon : '') + '</span> ' + escapeHtml(q.categoryName) + '</span></div>' +
+      '<p class="desc">' + escapeHtml(q.shortDescription) + '</p>' +
+      '<div class="path mono">quests/' + escapeHtml(q.id) + '.html</div>' +
+      '<div class="card-foot">' +
+      '<span class="badge-diff ' + diff + '">' + escapeHtml(q.difficulty) + '</span>' +
+      '<span class="card-links">' +
+      '<a class="link-btn" href="quests/' + escapeAttr(q.id) + '.html" data-nomodal>Preview</a>' +
+      '<a class="link-btn primary" href="' + escapeAttr(liveUrl) + '" target="_blank" rel="noopener noreferrer" data-nomodal>Start Quest <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg></a>' +
+      '</span></div></div></article>';
+  }).join("\n");
+}
+
 // ── Build resume/portfolio showcase cards (static HTML) ──
 
 function buildThemeCard(t, glyph) {
@@ -339,6 +431,11 @@ const toolsJson = JSON.stringify(toolsData.map((t) => ({
 })));
 const resumeThemesJson = JSON.stringify(resumeThemes);
 const portfolioThemesJson = JSON.stringify(portfolioThemes);
+const questsJson = JSON.stringify(questsDataBuilt.map((q) => ({
+  id: q.id, name: q.name, shortDescription: q.shortDescription, longDescription: quests.find((x) => x.id === q.id)?.longDescription || "",
+  category: q.category, tags: q.tags, techStack: q.techStack, difficulty: q.difficulty
+})));
+const questCategoriesJson = JSON.stringify(questCategories.map((c) => ({ id: c.id, name: c.name, icon: c.icon })));
 
 // ── Inject into template ──
 
@@ -350,16 +447,21 @@ let html = template
   .replace(/\{\{SSOC_URL\}\}/g, escapeAttr(site.ssoc.url))
   .replace(/\{\{YEAR\}\}/g, new Date().getFullYear().toString())
   .replace(/\{\{TOOL_COUNT\}\}/g, String(totalCount))
+  .replace(/\{\{QUEST_COUNT\}\}/g, String(totalQuestCount))
   .replace("{{PILLAR_CARDS}}", buildPillarCards())
   .replace("{{FILTER_PILLS}}", buildFilterPills())
   .replace("{{TOOL_CARDS}}", buildToolCards())
   .replace("{{RESUME_CARDS}}", buildResumeCards())
   .replace("{{PORTFOLIO_CARDS}}", buildPortfolioCards())
+  .replace("{{QUEST_FILTER_PILLS}}", buildQuestFilterPills())
+  .replace("{{QUEST_CARDS}}", buildQuestCards())
   .replace("{{SITE_JSON}}", siteJson)
   .replace("{{CATEGORIES_JSON}}", categoriesJson)
   .replace("{{TOOLS_JSON}}", toolsJson)
   .replace("{{RESUME_THEMES_JSON}}", resumeThemesJson)
-  .replace("{{PORTFOLIO_THEMES_JSON}}", portfolioThemesJson);
+  .replace("{{PORTFOLIO_THEMES_JSON}}", portfolioThemesJson)
+  .replace("{{QUESTS_JSON}}", questsJson)
+  .replace("{{QUEST_CATEGORIES_JSON}}", questCategoriesJson);
 
 // ──────────────────────────────────────────────
 // Write output
@@ -370,6 +472,7 @@ fs.writeFileSync(outPath, html, "utf-8");
 
 console.log("Built index.html successfully.");
 console.log("  " + totalCount + " tools across " + categories.length + " categories (" + liveCount + " live, " + (totalCount - liveCount) + " ideas)");
+console.log("  " + totalQuestCount + " quests across " + questCategories.length + " categories");
 console.log("  Template: " + templatePath);
 console.log("  Output: " + outPath);
 

--- a/scripts/index-template.txt
+++ b/scripts/index-template.txt
@@ -1312,6 +1312,38 @@
             <span>All portfolio themes are generated from <code>profile.json</code> — edit your data once, get every theme.</span>
           </div>
         </section>
+
+        <!-- ===================== QUESTS SECTION ===================== -->
+        <section class="section" id="section-quests" aria-labelledby="quests-heading">
+          <div class="section-head">
+            <div class="kicker">~/quests</div>
+            <h2 id="quests-heading">One File Quests</h2>
+            <p>Interactive, gamified lessons for learning Git, CSS, and JavaScript by doing — each one a single HTML file with progress saved locally in your browser.</p>
+          </div>
+
+          <div class="toolbar">
+            <div class="search">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="7" />
+                <path d="m21 21-4.3-4.3" />
+              </svg>
+              <input type="search" id="questSearch" placeholder="Search quests…" aria-label="Search quests" autocomplete="off" />
+            </div>
+            <div class="filters" id="questFilters" role="group" aria-label="Filter quests by category">
+{{QUEST_FILTER_PILLS}}
+            </div>
+          </div>
+
+          <p class="count-row" id="questCountRow" aria-live="polite"><b>{{QUEST_COUNT}}</b> quests</p>
+          <div class="grid" id="questGrid">
+{{QUEST_CARDS}}
+          </div>
+
+          <div class="contribute-cta">
+            <p><strong>Want to add a quest?</strong> Check the quests contributing guide and submit a PR.</p>
+            <a class="link-btn primary" href="{{GITHUB_URL}}/blob/main/quests/Contributing.md" target="_blank" rel="noopener noreferrer">Contributing Guide <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg></a>
+          </div>
+        </section>
       </div>
     </main>
 
@@ -1370,6 +1402,8 @@
       const TOOLS = {{TOOLS_JSON}};
       const RESUME_THEMES = {{RESUME_THEMES_JSON}};
       const PORTFOLIO_THEMES = {{PORTFOLIO_THEMES_JSON}};
+      const QUESTS = {{QUESTS_JSON}};
+      const QUEST_CATEGORIES = {{QUEST_CATEGORIES_JSON}};
 
       /* =================================================================
    UTILITIES
@@ -1377,6 +1411,7 @@
       const $ = (sel, ctx = document) => ctx.querySelector(sel);
       const $$ = (sel, ctx = document) => Array.from(ctx.querySelectorAll(sel));
       const catById = (id) => CATEGORIES.find((c) => c.id === id);
+      const questCatById = (id) => QUEST_CATEGORIES.find((c) => c.id === id);
 
       function escapeHtml(str) {
         return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
@@ -1428,7 +1463,7 @@
       /* =================================================================
    PILLARS
    ================================================================= */
-      const VALID_PILLARS = ["tools", "resume", "portfolio"];
+      const VALID_PILLARS = ["tools", "resume", "portfolio", "quests"];
       let currentPillar = "tools";
 
       $$(".pillar[data-pillar]").forEach((btn) => {
@@ -1496,6 +1531,49 @@
       }
 
       /* =================================================================
+   QUESTS: search + filter (same pattern as tools)
+   ================================================================= */
+      let questActiveCategory = "all";
+      let questSearchTerm = "";
+
+      $$("#questFilters .pill").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          questActiveCategory = btn.dataset.cat;
+          $$("#questFilters .pill").forEach((b) => b.setAttribute("aria-pressed", String(b === btn)));
+          filterAndUpdateQuests();
+        });
+      });
+
+      function filterAndUpdateQuests() {
+        const q = questSearchTerm.trim().toLowerCase();
+        const cards = $$("#questGrid .card");
+        let visible = 0;
+
+        cards.forEach((card) => {
+          const cat = card.dataset.category;
+          const hay = card.dataset.search;
+          const catMatch = questActiveCategory === "all" || cat === questActiveCategory;
+          const searchMatch = !q || hay.includes(q);
+          const show = catMatch && searchMatch;
+          card.style.display = show ? "" : "none";
+          if (show) visible++;
+        });
+
+        const catName = questActiveCategory !== "all" ? (questCatById(questActiveCategory) || {}).name || questActiveCategory : "";
+        const countEl = $("#questCountRow");
+        countEl.innerHTML = "<b>" + visible + "</b> " + (visible === 1 ? "quest" : "quests") +
+          (catName ? " in " + escapeHtml(catName) : "") +
+          (q ? " matching \u201C" + escapeHtml(questSearchTerm.trim()) + "\u201D" : "");
+      }
+
+      $("#questSearch").addEventListener("input", (e) => {
+        questSearchTerm = e.target.value;
+        filterAndUpdateQuests();
+      });
+
+      filterAndUpdateQuests();
+
+      /* =================================================================
    Cmd/Ctrl+K to focus search
    ================================================================= */
       document.addEventListener("keydown", (e) => {
@@ -1514,18 +1592,26 @@
       const modal = $("#modal");
       let lastFocused = null;
 
-      function showModal(toolId, pushHash) {
-        const t = TOOLS.find((x) => x.id === toolId);
+      function showModal(itemId, pushHash, kind) {
+        kind = kind || "tools";
+        const isQuest = kind === "quests";
+        const collection = isQuest ? QUESTS : TOOLS;
+        const catLookup = isQuest ? questCatById : catById;
+        const folder = isQuest ? "quests" : "tools";
+        const openLabel = isQuest ? "Preview file" : "Open file";
+        const liveLabel = isQuest ? "Start quest " : "Try live ";
+
+        const t = collection.find((x) => x.id === itemId);
         if (!t) return;
-        const cat = catById(t.category);
+        const cat = catLookup(t.category);
         const diff = t.difficulty.toLowerCase();
-        const live = SITE.url + "/tools/" + t.id;
+        const live = SITE.url + "/" + folder + "/" + t.id;
 
         $("#modalTitle").textContent = t.name;
         $("#modalMeta").innerHTML =
           '<span class="badge-cat"><span aria-hidden="true">' + (cat ? cat.icon : "") + "</span> " + escapeHtml(cat ? cat.name : t.category) + "</span>" +
           '<span class="badge-diff ' + diff + '">' + escapeHtml(t.difficulty) + "</span>" +
-          '<span class="path mono" style="margin-left:auto">tools/' + escapeHtml(t.id) + ".html</span>";
+          '<span class="path mono" style="margin-left:auto">' + folder + "/" + escapeHtml(t.id) + ".html</span>";
 
         $("#modalBody").innerHTML = parseMarkdown(t.longDescription) +
           '<div class="modal-tags">' +
@@ -1533,13 +1619,13 @@
           '<div class="lbl">// tags</div><div class="tag-row">' + t.tags.map((s) => '<span class="tag">' + escapeHtml(s) + "</span>").join("") + "</div></div>";
 
         $("#modalFoot").innerHTML =
-          '<a class="link-btn" href="tools/' + escapeHtml(t.id) + '.html">Open file</a>' +
-          '<a class="link-btn primary" href="' + escapeHtml(live) + '" target="_blank" rel="noopener noreferrer">Try live ' +
+          '<a class="link-btn" href="' + folder + "/" + escapeHtml(t.id) + '.html">' + openLabel + '</a>' +
+          '<a class="link-btn primary" href="' + escapeHtml(live) + '" target="_blank" rel="noopener noreferrer">' + liveLabel +
           '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg></a>';
 
         lastFocused = document.activeElement;
         if (!modal.open) modal.showModal();
-        if (pushHash) history.replaceState(null, "", "#tools/" + t.id);
+        if (pushHash) history.replaceState(null, "", "#" + kind + "/" + t.id);
         $("#modalClose").focus();
       }
 
@@ -1547,6 +1633,8 @@
         if (modal.open) modal.close();
         if (restoreHash && location.hash.startsWith("#tools/")) {
           history.replaceState(null, "", "#tools");
+        } else if (restoreHash && location.hash.startsWith("#quests/")) {
+          history.replaceState(null, "", "#quests");
         }
       }
 
@@ -1555,20 +1643,24 @@
       modal.addEventListener("cancel", () => closeModal(true));
       modal.addEventListener("close", () => { if (lastFocused && typeof lastFocused.focus === "function") lastFocused.focus(); });
 
-      /* Card click → modal */
-      $$("#toolGrid .card").forEach((card) => {
-        const openModal = () => showModal(card.dataset.id, true);
-        card.addEventListener("click", (e) => {
-          if (e.target.closest("[data-nomodal]")) return;
-          openModal();
-        });
-        card.addEventListener("keydown", (e) => {
-          if ((e.key === "Enter" || e.key === " ") && !e.target.closest("[data-nomodal]")) {
-            e.preventDefault();
+      /* Card click → modal (shared by tools and quests grids) */
+      function wireCardModals(gridId, kind) {
+        $$("#" + gridId + " .card").forEach((card) => {
+          const openModal = () => showModal(card.dataset.id, true, kind);
+          card.addEventListener("click", (e) => {
+            if (e.target.closest("[data-nomodal]")) return;
             openModal();
-          }
+          });
+          card.addEventListener("keydown", (e) => {
+            if ((e.key === "Enter" || e.key === " ") && !e.target.closest("[data-nomodal]")) {
+              e.preventDefault();
+              openModal();
+            }
+          });
         });
-      });
+      }
+      wireCardModals("toolGrid", "tools");
+      wireCardModals("questGrid", "quests");
 
       /* =================================================================
    HASH ROUTING
@@ -1577,11 +1669,16 @@
         const hash = location.hash.replace(/^#/, "");
         if (!hash) { selectPillar("tools", { scroll: false }); return; }
 
-        const [pillar, toolId] = hash.split("/");
+        const [pillar, itemId] = hash.split("/");
 
-        if (pillar === "tools" && toolId) {
+        if (pillar === "tools" && itemId) {
           selectPillar("tools", { scroll: false });
-          if (TOOLS.some((t) => t.id === toolId)) { showModal(toolId, false); return; }
+          if (TOOLS.some((t) => t.id === itemId)) { showModal(itemId, false, "tools"); return; }
+        }
+
+        if (pillar === "quests" && itemId) {
+          selectPillar("quests", { scroll: false });
+          if (QUESTS.some((q) => q.id === itemId)) { showModal(itemId, false, "quests"); return; }
         }
 
         if (VALID_PILLARS.includes(pillar)) {

--- a/scripts/sort-norm.js
+++ b/scripts/sort-norm.js
@@ -60,6 +60,21 @@ if (Array.isArray(data.tools)) {
   }
 }
 
+// Normalize and sort quests
+if (Array.isArray(data.quests)) {
+  data.quests.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const quest of data.quests) {
+    if (Array.isArray(quest.tags)) {
+      quest.tags = [...new Set(quest.tags.map(normalizeTag))].sort((a, b) => a.localeCompare(b));
+    }
+
+    if (Array.isArray(quest.techStack)) {
+      quest.techStack.sort((a, b) => a.localeCompare(b));
+    }
+  }
+}
+
 // Sort theme arrays (themes.json: { resume: [...], portfolio: [...] })
 for (const pillar of ["resume", "portfolio"]) {
   if (Array.isArray(data[pillar])) {


### PR DESCRIPTION
## What does this PR do?
Adds the infrastructure for a new "Quests" pillar-  interactive, gamified learning modules (e.g. Git branching, CSS fundamentals) as single self-contained HTML files, following the same one-file-zero-dependency philosophy as the rest of the repo.

This PR is infrastructure only - no quest content is included yet. It adds:
- `data/quests.json` -  a new registry, same schema as `tools.json`, currently empty (3 categories defined, 0 quests)
- `quests/` folder and `quests/Contributing.md`, mirroring `tools/Contributing.md`
- `scripts/build.js`:  reads `quests.json`, builds quest cards, replaces the previous static "More coming soon…" pillar slot with a real Quests pillar (a new muted "coming soon" slot now sits after it)
- `scripts/index-template.txt` - adds a Quests section (search, filter, grid, modal support) following the existing Tools section's pattern
- `scripts/sort-norm.js` and `package.json` - extended so `npm run sort` also normalizes `data/quests.json`

Existing Tools, Resume, and Portfolio sections were tested and confirmed to render and function exactly as before this change. A follow-up PR will add the first real quest once this is merged and confirmed stable.

Closes #204 

## Type of Change
- [ ] New tool
- [ ] Enhancement to existing tool
- [ ] Bug fix
- [ ] Documentation update
- [x] Build system / infrastructure

## Screenshot
<!-- attach a screenshot showing the new Quests pillar / empty state here -->
<img width="1352" height="757" alt="Screenshot 2026-07-05 at 8 09 02 PM" src="https://github.com/user-attachments/assets/16004f74-e2ac-4b9f-a2b3-c02e3301d208" />
<img width="1338" height="661" alt="Screenshot 2026-07-05 at 8 09 09 PM" src="https://github.com/user-attachments/assets/d8db557c-300c-4e02-a3d7-9b3e55e84993" />
<img width="959" height="271" alt="Screenshot 2026-07-05 at 8 10 07 PM" src="https://github.com/user-attachments/assets/1f169ca0-38b9-4e26-a74c-d00311bdaf7a" />


## Checklist
- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser
### For new tools:
- [ ] The tool is a single self-contained `.html` file in the `tools/` folder
- [ ] The filename is kebab-case (e.g. `json-formatter.html`)
- [ ] I added an entry to `data/tools.json` with all required fields
- [ ] I added a screenshot as `tools/<tool-name>.png` next to the HTML file
- [ ] No JS frameworks (React, Vue, Angular, etc.) or heavy UI libraries (Bootstrap JS, jQuery, etc.)
- [ ] CDN links for lightweight libraries and fonts are fine — no copy-pasting library source code inline
- [ ] I ran `node scripts/sort-norm.js data/tools.json` to sort and normalize the tools registry
- [ ] I ran `node scripts/build.js` and verified the landing page renders correctly
### For enhancements / bug fixes:
- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file