### PR TITLE
security: prevent javascript: URI execution in metadata and favicon links

### DIFF
--- a/tools/open-graph-inspector.html
+++ b/tools/open-graph-inspector.html
@@ -1571,6 +1571,16 @@
         }
       }
 
+      function isSafeUrl(url) {
+        if (!url) return false;
+        try {
+          const parsed = new URL(url, window.location.href);
+          return parsed.protocol === "http:" || parsed.protocol === "https:";
+        } catch {
+          return false;
+        }
+      }
+
       /* -------------------------------------------------------
    10. HTML PARSING — METADATA EXTRACTION
    ------------------------------------------------------- */
@@ -2068,7 +2078,7 @@
           ["robots", data.seo.robots],
           ["canonical", data.seo.canonical, true]
         ])}
-        ${data.favicon ? `<div class="meta-row"><span class="meta-key">favicon</span><span class="meta-value"><img src="${escHtml(data.favicon)}" style="width:16px;height:16px;vertical-align:middle;margin-right:6px;" onerror="this.style.display='none'"><a href="${escHtml(data.favicon)}" target="_blank" rel="noopener">${escHtml(data.favicon)}</a></span></div>` : ""}
+        ${data.favicon ? `<div class="meta-row"><span class="meta-key">favicon</span><span class="meta-value">${isSafeUrl(data.favicon) ? `<img src="${escHtml(data.favicon)}" style="width:16px;height:16px;vertical-align:middle;margin-right:6px;" onerror="this.style.display='none'"><a href="${escHtml(data.favicon)}" target="_blank" rel="noopener">${escHtml(data.favicon)}</a>` : escHtml(data.favicon)}</span></div>` : ""}
       </div>
     </div>`;
 
@@ -2165,7 +2175,7 @@
       function renderMetaRows(rows) {
         return rows
           .map(([key, val, isUrl]) => {
-            const display = val ? (isUrl ? `<a href="${escHtml(val)}" target="_blank" rel="noopener">${escHtml(val)}</a>` : escHtml(val)) : '<span class="missing">Not set</span>';
+            const display = val ? (isUrl && isSafeUrl(val) ? `<a href="${escHtml(val)}" target="_blank" rel="noopener">${escHtml(val)}</a>` : escHtml(val)) : '<span class="missing">Not set</span>';
             return `<div class="meta-row"><span class="meta-key">${escHtml(key)}</span><span class="meta-value${val ? "" : " missing"}">${display}</span></div>`;
           })
           .join("");


### PR DESCRIPTION

### Description
Fixes a high-severity security issue where user-controlled canonical URLs and favicons are rendered as clickable `<a>` links without protocol validation, allowing execution of `javascript:` links.
Closes #353
### Changes
- Added an `isSafeUrl` utility function:
  ```javascript
  function isSafeUrl(url) {
    if (!url) return false;
    try {
      const parsed = new URL(url, window.location.href);
      return parsed.protocol === "http:" || parsed.protocol === "https:";
    } catch {
      return false;
    }
  }
  ```
- Wrapped meta row links and favicons to check `isSafeUrl` before generating clickable elements, falling back to plain text if the scheme is unsafe.

### Verification
- Paste HTML containing a `javascript:` canonical URL:
  `<link rel="canonical" href="javascript:alert(1)" />`
- Verified it displays as plain text in the results grid and clicking it does not execute script.