### PR TITLE
fix: resolve keyboard focus loss in contrast checker format tabs and dns lookup chips

### DIFF
--- a/tools/contrast-checker-a11y.html
+++ b/tools/contrast-checker-a11y.html
@@ -684,18 +684,27 @@ Built for One File Tools.
 
       // ---- Rendering ----
 
-      function buildFormatTabs(container, getFormat, setFormat) {
+      function initFormatTabs(container, getFormat, setFormat, prefix) {
         container.innerHTML = "";
         ["hex", "rgb", "hsl"].forEach((format) => {
           const btn = document.createElement("button");
           btn.type = "button";
-          btn.className = "format-tab" + (getFormat() === format ? " active" : "");
+          btn.className = "format-tab";
           btn.textContent = format.toUpperCase();
+          btn.dataset.format = format;
+          btn.dataset.prefix = prefix;
           btn.addEventListener("click", () => {
             setFormat(format);
             render();
           });
           container.appendChild(btn);
+        });
+      }
+
+      function updateFormatTabs(container, getFormat) {
+        container.querySelectorAll(".format-tab").forEach((btn) => {
+          const active = btn.dataset.format === getFormat();
+          btn.className = "format-tab" + (active ? " active" : "");
         });
       }
 
@@ -705,16 +714,8 @@ Built for One File Tools.
         fgPicker.value = rgbToHex(fgRgb);
         bgPicker.value = rgbToHex(bgRgb);
 
-        buildFormatTabs(
-          fgFormatTabs,
-          () => fgFormat,
-          (f) => (fgFormat = f)
-        );
-        buildFormatTabs(
-          bgFormatTabs,
-          () => bgFormat,
-          (f) => (bgFormat = f)
-        );
+        updateFormatTabs(fgFormatTabs, () => fgFormat);
+        updateFormatTabs(bgFormatTabs, () => bgFormat);
 
         const ratio = contrastRatio(fgRgb, bgRgb);
         ratioNumber.textContent = ratio.toFixed(2) + ":1";
@@ -822,6 +823,8 @@ Built for One File Tools.
         }
       });
 
+      initFormatTabs(fgFormatTabs, () => fgFormat, (f) => (fgFormat = f), "fg");
+      initFormatTabs(bgFormatTabs, () => bgFormat, (f) => (bgFormat = f), "bg");
       render();
     </script>
   </body>

--- a/tools/dns-record-lookup.html
+++ b/tools/dns-record-lookup.html
@@ -500,24 +500,35 @@ Built for One File Tools.
         }
       }
 
-      /** Renders the record-type selector chips. */
-      function renderTypeChips() {
+      /** Initializes the record-type selector chips once. */
+      function initTypeChips() {
         recordTypesRow.innerHTML = "";
         RECORD_TYPES.forEach((type) => {
           const chip = document.createElement("button");
           chip.type = "button";
-          chip.className = "type-chip" + (type === activeType ? " active" : "");
+          chip.className = "type-chip";
           chip.textContent = type;
+          chip.dataset.type = type;
           chip.addEventListener("click", () => {
             activeType = type;
-            renderTypeChips();
+            updateTypeChips();
           });
           recordTypesRow.appendChild(chip);
         });
       }
 
+      /** Updates the active state class on the record-type chips. */
+      function updateTypeChips() {
+        recordTypesRow.querySelectorAll(".type-chip").forEach((chip) => {
+          const active = chip.dataset.type === activeType;
+          chip.className = "type-chip" + (active ? " active" : "");
+        });
+      }
+
       /** Renders the session query-history chips (most recent first). */
       function renderHistory() {
+        const wasFocusInHistory = historyList.contains(document.activeElement);
+
         historyList.innerHTML = "";
         history.forEach((item) => {
           const chip = document.createElement("button");
@@ -527,11 +538,15 @@ Built for One File Tools.
           chip.addEventListener("click", () => {
             domainInput.value = item.domain;
             activeType = item.type;
-            renderTypeChips();
+            updateTypeChips();
             performLookup();
           });
           historyList.appendChild(chip);
         });
+
+        if (wasFocusInHistory && historyList.firstElementChild) {
+          historyList.firstElementChild.focus();
+        }
       }
 
       /** Formats a DNS record's rdata into a readable string based on its type. */
@@ -698,7 +713,8 @@ Built for One File Tools.
         setTimeout(() => URL.revokeObjectURL(url), 0);
       });
 
-      renderTypeChips();
+      initTypeChips();
+      updateTypeChips();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #403 
### Description
This PR addresses critical keyboard focus loss bugs (accessibility and UX concerns) in two newly added developer tools:

1. **Contrast Checker (A11y) (`tools/contrast-checker-a11y.html`)**
   - **Problem**: Selecting format tabs (HEX, RGB, HSL) deleted all format buttons and appended new ones, causing the browser to reset focus to the document body.
   - **Solution**: Refactored tab rendering into static initialization (`initFormatTabs()`, run once on startup) and class updates (`updateFormatTabs()`, run on changes). Updates now modify classes on existing buttons without removing them, preserving focus.

2. **DNS Record Lookup (`tools/dns-record-lookup.html`)**
   - **Problem**: Toggling record type chips (A, AAAA, MX, NS, etc.) destroyed and recreated the chips on every click. Similarly, clicking a history chip recreated the query history list, resetting active focus.
   - **Solution**:
     - Refactored record type chips to initialize once (`initTypeChips()`) and toggle active classes dynamically (`updateTypeChips()`), maintaining active focus.
     - Updated `renderHistory()` to check if the user had active focus inside the history list before reconstruction. If so, it programmatically restores focus to the first history chip (representing the newly queried item) in the rebuilt list.

### Verification
- Ran `node scripts/validate.js` and confirmed that **all validations now pass cleanly (0 errors)**.
- Ran `npm run build` and confirmed that `index.html` generates successfully.
- Opened both tools in the browser and verified that toggling formats, record types, and history chips via keyboard (`Space`/`Enter`) no longer resets the focus state.