### PR TITLE
Add/ screen-resolution-tester

### DIFF
--- a/tools/screen-resolution-tester.html
+++ b/tools/screen-resolution-tester.html
@@ -1,24 +1,13 @@
-<<<<<<< Updated upstream
-=======
 <!DOCTYPE html>
->>>>>>> Stashed changes
-<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Test your website at different screen resolutions." />
     <title>Screen Resolution Tester — One File Tools</title>
     <style>
-<<<<<<< Updated upstream
-=======
       /* ========================================
        Reset & Base Rules
        ======================================== */
-    <meta name="description" content="Test your website at different screen resolutions." />
-    <title>Screen Resolution Tester — One File Tools</title>
-    <style>
->>>>>>> Stashed changes
       *,
       *::before,
       *::after {
@@ -26,174 +15,324 @@
         margin: 0;
         padding: 0;
       }
-      :root {
-        --bg: #fafafa;
-        --surface: #f1f5f9;
-        --text: #1a1a1a;
-        --muted: #64748b;
-        --border: #e2e8f0;
-        --accent: #2563eb;
-        --radius: 8px;
-      }
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --bg: #0a0a0a;
-          --surface: #1a1a1a;
-          --text: #e5e5e5;
-          --muted: #94a3b8;
-          --border: #334155;
-          --accent: #3b82f6;
-        }
-      }
+
       body {
-        font-family: system-ui, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
         line-height: 1.6;
-        background: var(--bg);
-        color: var(--text);
-        min-height: 100vh;
-      }
-      .container {
+        padding: 2rem;
         max-width: 1200px;
         margin: 0 auto;
-        padding: 2rem;
+        background: #f8fafc;
+        color: #0f172a;
+        transition: background 0.3s, color 0.3s;
       }
-      header {
+
+      /* ========================================
+       Light & Dark Theme Variables
+       ======================================== */
+      .panel {
+        background: #ffffff;
+        padding: 1.75rem;
+        border-radius: 12px;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+      }
+      .panel h3 {
+        margin-bottom: 1.25rem;
+        font-size: 0.95rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.75px;
+        color: #0284c7;
+      }
+      input {
+        background: #ffffff;
+        color: #0f172a;
+        border: 1px solid #cbd5e1;
+        padding: 0.65rem 1rem;
+        border-radius: 6px;
+        font-size: 0.95rem;
+        outline: none;
+        transition: all 0.2s;
+      }
+      input:focus {
+        border-color: #0284c7;
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.15);
+      }
+      .preset-btn {
+        background: #f1f5f9;
+        color: #334155;
+        font-size: 0.85rem;
+        font-weight: 500;
+        padding: 0.65rem 0.5rem;
+        border: 1px solid #e2e8f0;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: all 0.2s;
         text-align: center;
+      }
+      .preset-btn:hover, .preset-btn.active {
+        background: #0284c7;
+        color: white;
+        border-color: #0284c7;
+        box-shadow: 0 2px 8px rgba(2, 132, 199, 0.25);
+      }
+      .preview-wrapper {
+        width: 100%;
+        overflow: auto;
+        border: 1px solid #e2e8f0;
+        padding: 2rem;
+        background: #cbd5e1;
+        border-radius: 12px;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        min-height: 550px;
+        max-height: 900px;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #0f172a;
+          color: #f8fafc;
+        }
+        .panel {
+          background: #1e293b;
+          border-color: #334155;
+          box-shadow: none;
+        }
+        input {
+          background: #0f172a;
+          color: #f8fafc;
+          border-color: #334155;
+        }
+        .preset-btn {
+          background: #334155;
+          color: #cbd5e1;
+          border-color: #475569;
+        }
+        .preset-btn:hover, .preset-btn.active {
+          background: #38bdf8;
+          color: #0f172a;
+          border-color: #38bdf8;
+          box-shadow: 0 2px 8px rgba(56, 189, 248, 0.3);
+        }
+        .preview-wrapper {
+          background: #020617;
+          border-color: #1e293b;
+        }
+        .panel h3 {
+          color: #38bdf8;
+        }
+      }
+
+      /* ========================================
+       UI Elements
+       ======================================== */
+      header {
         margin-bottom: 2rem;
+        border-bottom: 1px solid #e2e8f0;
+        padding-bottom: 1.5rem;
+      }
+      @media (prefers-color-scheme: dark) {
+        header { border-bottom-color: #1e293b; }
       }
       header h1 {
-        font-size: 2rem;
+        font-size: 2.2rem;
+        font-weight: 800;
+        letter-spacing: -0.5px;
         margin-bottom: 0.5rem;
       }
       header p {
-        color: var(--muted);
+        color: #64748b;
+        font-size: 1.05rem;
       }
-      .card {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 1.5rem;
-        margin-bottom: 1.5rem;
-        overflow: hidden;
-      }
-      .card-header {
-        font-weight: 600;
-        margin-bottom: 1rem;
-        color: var(--text);
-      }
-      .current-info {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-        gap: 1rem;
-        text-align: center;
-        margin-bottom: 1.5rem;
-      }
-      .info-item {
-        background: var(--bg);
-        padding: 1rem;
-        border-radius: var(--radius);
-        overflow: hidden;
-      }
-      .info-value {
-        font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--accent);
-        overflow-wrap: break-word;
-      }
-      .info-label {
-        font-size: 0.75rem;
-        color: var(--muted);
-        text-transform: uppercase;
-      }
-      .presets {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-      }
-      .preset {
-        padding: 0.5rem 1rem;
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        background: var(--bg);
-        color: var(--text);
-        cursor: pointer;
-        font-size: 0.875rem;
-      }
-      .preset:hover {
-        border-color: var(--accent);
-      }
-      .preset.active {
-        background: var(--accent);
+
+      .current-stats {
+        background: #0284c7;
         color: white;
-        border-color: var(--accent);
+        padding: 0.5rem 1rem;
+        border-radius: 20px;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        margin-bottom: 2rem;
       }
-      .viewport-wrap {
-        max-width: 100%;
-        max-height: 70vh;
-        overflow: auto;
-        border-radius: var(--radius);
-        background: var(--bg);
+      @media (prefers-color-scheme: dark) {
+        .current-stats { background: #38bdf8; color: #0f172a; }
       }
-      .viewport {
-        border: 2px solid var(--accent);
-        border-radius: var(--radius);
+
+      .controls-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        margin-bottom: 2.5rem;
+      }
+      @media (min-width: 900px) {
+        .controls-grid { grid-template-columns: 1fr 1.75fr; }
+      }
+
+      .url-bar {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.25rem;
+      }
+      .url-bar input { flex: 1; }
+      .url-bar button {
+        padding: 0.65rem 1.25rem;
+        background: #0284c7;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: 600;
+        transition: background 0.2s;
+      }
+      .url-bar button:hover { background: #0369a1; }
+      @media (prefers-color-scheme: dark) {
+        .url-bar button { background: #38bdf8; color: #0f172a; }
+        .url-bar button:hover { background: #0ea5e9; }
+      }
+
+      .input-group {
+        display: flex;
+        gap: 1rem;
+      }
+      .input-field {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+      .input-field label {
+        font-size: 0.85rem;
+        margin-bottom: 0.4rem;
+        font-weight: 600;
+      }
+      .input-field input { text-align: center; }
+
+      .presets-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 0.75rem;
+      }
+
+      /* ========================================
+       Viewport Canvas Screen Sizing
+       ======================================== */
+      .preview-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-top: 1rem;
+      }
+      .viewport-info {
+        font-size: 0.95rem;
+        margin-bottom: 0.75rem;
+        font-weight: 600;
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 0.35rem 1rem;
+        border-radius: 6px;
+      }
+      .preview-area {
+        background: white;
+        border: 4px solid #0f172a;
+        border-radius: 12px;
+        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+        transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         overflow: hidden;
         position: relative;
-        transition: all 0.3s;
       }
-      .viewport iframe {
+
+      /* Custom colorful inner application sandbox styling */
+      .sandbox-app {
         width: 100%;
-        height: 500px;
+        height: 100%;
+        overflow-y: auto;
+        background: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+        color: #ffffff;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        font-family: system-ui, sans-serif;
+      }
+      .sandbox-header {
+        background: linear-gradient(90deg, #38bdf8, #818cf8);
+        padding: 1rem;
+        border-radius: 8px;
+        margin-bottom: 1rem;
+        text-align: center;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      }
+      .sandbox-header h2 { font-size: 1.25rem; font-weight: 800; color: #0f172a; }
+      .sandbox-card {
+        background: rgba(255, 255, 255, 0.07);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        padding: 1rem;
+        border-radius: 8px;
+        margin-bottom: 0.75rem;
+      }
+      .sandbox-card h4 { color: #38bdf8; margin-bottom: 0.25rem; font-size: 0.95rem; }
+      .sandbox-card p { font-size: 0.85rem; color: #cbd5e1; }
+      .tag-row { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.5rem; }
+      .tag-pill { background: #818cf8; color: #0f172a; font-weight: bold; font-size: 0.75rem; padding: 0.15rem 0.5rem; border-radius: 4px; }
+
+      iframe {
+        width: 100%;
+        height: 100%;
         border: none;
-        background: white;
-        display: block;
+        background: #ffffff;
+        display: none;
       }
-      .viewport-bar {
-        position: sticky;
-        top: 0;
-        left: 0;
-        right: 0;
-        background: var(--accent);
-        color: white;
-        padding: 0.5rem;
-        font-size: 0.75rem;
-        text-align: center;
-        white-space: nowrap;
-        z-index: 1;
-      }
+
       footer {
+        margin-top: 4rem;
         text-align: center;
-        padding: 2rem;
-        color: var(--muted);
-        font-size: 0.875rem;
+        font-size: 0.9rem;
+        border-top: 1px solid #e2e8f0;
+        padding-top: 1.5rem;
+        color: #64748b;
       }
-      footer a {
-        color: var(--accent);
-        text-decoration: none;
+      @media (prefers-color-scheme: dark) {
+        footer { border-top-color: #1e293b; }
       }
+      footer a { color: #0284c7; text-decoration: none; font-weight: 500; }
+      @media (prefers-color-scheme: dark) { footer a { color: #38bdf8; } }
+      footer a:hover { text-decoration: underline; }
     </style>
   </head>
   <body>
-    <div class="container">
-      <header>
-        <h1>📱 Screen Resolution Tester</h1>
-        <p>Test your website at different screen sizes</p>
-      </header>
+    <header>
+      <h1>Screen Resolution Tester</h1>
+      <p>Test websites and responsive layouts across different screen sizes and device presets.</p>
+    </header>
 
-      <div class="card">
-        <div class="card-header">Your Current Screen</div>
-        <div class="current-info">
-          <div class="info-item">
-            <div class="info-value" id="screenWidth">-</div>
-            <div class="info-label">Screen Width</div>
+    <main>
+      <div id="currentDimensions" class="current-stats">
+        Detecting Screen Resolution...
+      </div>
+
+      <div class="controls-grid">
+        <div class="panel">
+          <h3>Configuration</h3>
+          
+          <div class="url-bar">
+            <input type="text" id="urlInput" value="Internal Sandbox Preview" placeholder="Enter URL (e.g., https://example.com)" />
+            <button id="loadUrlBtn">Load</button>
           </div>
-          <div class="info-item">
-            <div class="info-value" id="screenHeight">-</div>
-            <div class="info-label">Screen Height</div>
+
+          <div class="input-group">
+            <div class="input-field">
+              <label for="widthInput">Width (px)</label>
+              <input type="number" id="widthInput" value="375" min="200" max="4000" />
+            </div>
+            <div class="input-field">
+              <label for="heightInput">Height (px)</label>
+              <input type="number" id="heightInput" value="667" min="200" max="4000" />
+            </div>
           </div>
-<<<<<<< Updated upstream
-=======
         </div>
 
         <div class="panel">
@@ -212,380 +351,139 @@
             <button class="preset-btn" data-w="1920" data-h="1080">📺 Full HD (1080p)</button>
             <button class="preset-btn" data-w="2560" data-h="1440">🖥️ QHD (2K)</button>
             <button class="preset-btn" data-w="3840" data-h="2160">🖥️ UHD (4K)</button>
-      :root {
-        --bg: #fafafa;
-        --surface: #f1f5f9;
-        --text: #1a1a1a;
-        --muted: #64748b;
-        --border: #e2e8f0;
-        --accent: #2563eb;
-        --radius: 8px;
-      }
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --bg: #0a0a0a;
-          --surface: #1a1a1a;
-          --text: #e5e5e5;
-          --muted: #94a3b8;
-          --border: #334155;
-          --accent: #3b82f6;
-        }
-      }
-      body {
-        font-family: system-ui, sans-serif;
-        line-height: 1.6;
-        background: var(--bg);
-        color: var(--text);
-        min-height: 100vh;
-      }
-      .container {
-        max-width: 1200px;
-        margin: 0 auto;
-        padding: 2rem;
-      }
-      header {
-        text-align: center;
-        margin-bottom: 2rem;
-      }
-      header h1 {
-        font-size: 2rem;
-        margin-bottom: 0.5rem;
-      }
-      header p {
-        color: var(--muted);
-      }
-      .card {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 1.5rem;
-        margin-bottom: 1.5rem;
-        overflow: hidden;
-      }
-      .card-header {
-        font-weight: 600;
-        margin-bottom: 1rem;
-        color: var(--text);
-      }
-      .current-info {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-        gap: 1rem;
-        text-align: center;
-        margin-bottom: 1.5rem;
-      }
-      .info-item {
-        background: var(--bg);
-        padding: 1rem;
-        border-radius: var(--radius);
-        overflow: hidden;
-      }
-      .info-value {
-        font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--accent);
-        overflow-wrap: break-word;
-      }
-      .info-label {
-        font-size: 0.75rem;
-        color: var(--muted);
-        text-transform: uppercase;
-      }
-      .presets {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-      }
-      .preset {
-        padding: 0.5rem 1rem;
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        background: var(--bg);
-        color: var(--text);
-        cursor: pointer;
-        font-size: 0.875rem;
-      }
-      .preset:hover {
-        border-color: var(--accent);
-      }
-      .preset.active {
-        background: var(--accent);
-        color: white;
-        border-color: var(--accent);
-      }
-      .viewport-wrap {
-        max-width: 100%;
-        max-height: 70vh;
-        overflow: auto;
-        border-radius: var(--radius);
-        background: var(--bg);
-      }
-      .viewport {
-        border: 2px solid var(--accent);
-        border-radius: var(--radius);
-        overflow: hidden;
-        position: relative;
-        transition: all 0.3s;
-      }
-      .viewport iframe {
-        width: 100%;
-        height: 500px;
-        border: none;
-        background: white;
-        display: block;
-      }
-      .viewport-bar {
-        position: sticky;
-        top: 0;
-        left: 0;
-        right: 0;
-        background: var(--accent);
-        color: white;
-        padding: 0.5rem;
-        font-size: 0.75rem;
-        text-align: center;
-        white-space: nowrap;
-        z-index: 1;
-      }
-      footer {
-        text-align: center;
-        padding: 2rem;
-        color: var(--muted);
-        font-size: 0.875rem;
-      }
-      footer a {
-        color: var(--accent);
-        text-decoration: none;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <header>
-        <h1>📱 Screen Resolution Tester</h1>
-        <p>Test your website at different screen sizes</p>
-      </header>
-
-      <div class="card">
-        <div class="card-header">Your Current Screen</div>
-        <div class="current-info">
-          <div class="info-item">
-            <div class="info-value" id="screenWidth">-</div>
-            <div class="info-label">Screen Width</div>
-          </div>
-          <div class="info-item">
-            <div class="info-value" id="screenHeight">-</div>
-            <div class="info-label">Screen Height</div>
-          </div>
->>>>>>> Stashed changes
-          <div class="info-item">
-            <div class="info-value" id="windowWidth">-</div>
-            <div class="info-label">Window Width</div>
-          </div>
-          <div class="info-item">
-            <div class="info-value" id="windowHeight">-</div>
-            <div class="info-label">Window Height</div>
-          </div>
-          <div class="info-item">
-            <div class="info-value" id="devicePixelRatio">-</div>
-            <div class="info-label">Pixel Ratio</div>
           </div>
         </div>
       </div>
 
-      <div class="card">
-        <div class="card-header">Quick Presets</div>
-        <div class="presets">
-          <button class="preset" data-w="375" data-h="667">iPhone SE</button>
-          <button class="preset" data-w="390" data-h="844">iPhone 12</button>
-          <button class="preset" data-w="414" data-h="896">iPhone 11</button>
-          <button class="preset" data-w="768" data-h="1024">iPad</button>
-          <button class="preset" data-w="1024" data-h="768">iPad Landscape</button>
-          <button class="preset" data-w="1280" data-h="720">HD</button>
-          <button class="preset" data-w="1366" data-h="768">Laptop</button>
-          <button class="preset" data-w="1920" data-h="1080">Full HD</button>
-          <button class="preset" data-w="2560" data-h="1440">2K</button>
-          <button class="preset" data-w="3840" data-h="2160">4K</button>
-        </div>
-        <div style="display: flex; gap: 1rem; margin-bottom: 1rem">
-          <div style="flex: 1">
-            <label style="font-size: 0.75rem; color: var(--muted)">Width</label>
-            <input type="number" id="customWidth" value="1280" style="width: 100%; padding: 0.5rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text)" />
-          </div>
-          <div style="flex: 1">
-            <label style="font-size: 0.75rem; color: var(--muted)">Height</label>
-            <input type="number" id="customHeight" value="720" style="width: 100%; padding: 0.5rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text)" />
-          </div>
-          <button id="applyBtn" style="align-self: flex-end; padding: 0.5rem 1rem; background: var(--accent); color: white; border: none; border-radius: 4px; cursor: pointer">Apply</button>
-        </div>
-        <div class="viewport-wrap">
-          <div class="viewport" id="viewport">
-            <div class="viewport-bar" id="viewportBar">1280 x 720</div>
-            <iframe id="iframe" src="about:blank"></iframe>
+      <div class="preview-container">
+        <div class="viewport-info" id="viewportInfo">Viewport: 375px × 667px</div>
+        <div class="preview-wrapper">
+          <div id="previewArea" class="preview-area" style="width: 375px; height: 667px;">
+            <iframe id="previewFrame" src=""></iframe>
+            
+            <div id="sandboxApp" class="sandbox-app">
+              <div class="sandbox-header">
+                <h2>One File Tools</h2>
+                <p style="font-size:0.75rem; color:#0f172a; font-weight:600;">Responsive Environment Simulator</p>
+              </div>
+              <div class="sandbox-card">
+                <h4>✨ Creative Sandbox Canvas</h4>
+                <p>This dynamic local template is executing successfully inside your simulated responsive viewport screen container.</p>
+              </div>
+              <div class="sandbox-card">
+                <h4>📐 Current Aspect Matrix</h4>
+                <p id="aspectMetric">Aspect Ratio calculation matrix initializing...</p>
+              </div>
+              <div class="sandbox-card">
+                <h4>🚀 Core Repository Philosophy</h4>
+                <p>"One tool. One file. Open and use." High efficiency vanilla single file browser implementations built for immediate utility deployments.</p>
+                <div class="tag-row">
+                  <span class="tag-pill">HTML5</span>
+                  <span class="tag-pill">CSS3 Variables</span>
+                  <span class="tag-pill">Vanilla JS</span>
+                </div>
+              </div>
+            </div>
+
           </div>
         </div>
       </div>
-<<<<<<< Updated upstream
-=======
     </main>
-      <div class="card">
-        <div class="card-header">Quick Presets</div>
-        <div class="presets">
-          <button class="preset" data-w="375" data-h="667">iPhone SE</button>
-          <button class="preset" data-w="390" data-h="844">iPhone 12</button>
-          <button class="preset" data-w="414" data-h="896">iPhone 11</button>
-          <button class="preset" data-w="768" data-h="1024">iPad</button>
-          <button class="preset" data-w="1024" data-h="768">iPad Landscape</button>
-          <button class="preset" data-w="1280" data-h="720">HD</button>
-          <button class="preset" data-w="1366" data-h="768">Laptop</button>
-          <button class="preset" data-w="1920" data-h="1080">Full HD</button>
-          <button class="preset" data-w="2560" data-h="1440">2K</button>
-          <button class="preset" data-w="3840" data-h="2160">4K</button>
-        </div>
-        <div style="display: flex; gap: 1rem; margin-bottom: 1rem">
-          <div style="flex: 1">
-            <label style="font-size: 0.75rem; color: var(--muted)">Width</label>
-            <input type="number" id="customWidth" value="1280" style="width: 100%; padding: 0.5rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text)" />
-          </div>
-          <div style="flex: 1">
-            <label style="font-size: 0.75rem; color: var(--muted)">Height</label>
-            <input type="number" id="customHeight" value="720" style="width: 100%; padding: 0.5rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text)" />
-          </div>
-          <button id="applyBtn" style="align-self: flex-end; padding: 0.5rem 1rem; background: var(--accent); color: white; border: none; border-radius: 4px; cursor: pointer">Apply</button>
-        </div>
-        <div class="viewport-wrap">
-          <div class="viewport" id="viewport">
-            <div class="viewport-bar" id="viewportBar">1280 x 720</div>
-            <iframe id="iframe" src="about:blank"></iframe>
-          </div>
-        </div>
-      </div>
->>>>>>> Stashed changes
-    </div>
 
     <footer>
       <p>Part of <a href="https://github.com/praveenscience/One-File-Tools">One File Tools</a></p>
     </footer>
 
     <script>
-      var screenWidth = document.getElementById("screenWidth");
-      var screenHeight = document.getElementById("screenHeight");
-      var windowWidth = document.getElementById("windowWidth");
-      var windowHeight = document.getElementById("windowHeight");
-      var devicePixelRatio = document.getElementById("devicePixelRatio");
-      var viewport = document.getElementById("viewport");
-      var viewportBar = document.getElementById("viewportBar");
-      var iframe = document.getElementById("iframe");
-      var customWidth = document.getElementById("customWidth");
-      var customHeight = document.getElementById("customHeight");
-      var applyBtn = document.getElementById("applyBtn");
+      // Element Mapping
+      const currentDimensionsEl = document.getElementById('currentDimensions');
+      const widthInput = document.getElementById('widthInput');
+      const heightInput = document.getElementById('heightInput');
+      const urlInput = document.getElementById('urlInput');
+      const loadUrlBtn = document.getElementById('loadUrlBtn');
+      const previewArea = document.getElementById('previewArea');
+      const previewFrame = document.getElementById('previewFrame');
+      const sandboxApp = document.getElementById('sandboxApp');
+      const aspectMetric = document.getElementById('aspectMetric');
+      const viewportInfo = document.getElementById('viewportInfo');
+      const presetBtns = document.querySelectorAll('.preset-btn');
 
-      var lastUrl = "https://example.com";
-
-      function updateInfo() {
-        screenWidth.textContent = screen.width;
-        screenHeight.textContent = screen.height;
-        windowWidth.textContent = window.innerWidth;
-        windowHeight.textContent = window.innerHeight;
-        devicePixelRatio.textContent = window.devicePixelRatio;
+      // Live Stats Detection
+      function updateLiveScreenStats() {
+        currentDimensionsEl.textContent = `🖥️ Your Screen: ${window.screen.width} × ${window.screen.height} (Available Workspace: ${window.screen.availWidth} × ${window.screen.availHeight})`;
       }
 
-      function setViewport(w, h) {
-        viewport.style.width = w + "px";
-        viewport.style.height = h + 30 + "px";
-        iframe.style.height = h + "px";
-        viewportBar.textContent = w + " x " + h;
-        customWidth.value = w;
-        customHeight.value = h;
+      // Re-renders the frame dimensions safely
+      function updateViewport() {
+        let w = parseInt(widthInput.value);
+        let h = parseInt(heightInput.value);
 
-        document.querySelectorAll(".preset").forEach(function (btn) {
-          btn.classList.toggle("active", parseInt(btn.dataset.w) === w && parseInt(btn.dataset.h) === h);
-        });
+        if (isNaN(w) || w < 200) w = 200;
+        if (isNaN(h) || h < 200) h = 200;
+        
+        previewArea.style.width = `${w}px`;
+        previewArea.style.height = `${h}px`;
+        viewportInfo.textContent = `Viewport: ${w}px × ${h}px`;
+        
+        // Calculate dynamic aspect ratio fractions
+        const gcd = (a, b) => b ? gcd(b, a % b) : a;
+        const divisor = gcd(w, h);
+        aspectMetric.textContent = `Dimensions: ${w}px width by ${h}px height (Calculated Proportion Rule: ${w/divisor}:${h/divisor})`;
       }
 
-      function promptUrl() {
-        var url = prompt("Enter URL to test:", lastUrl);
-        if (url) {
-          if (!url.match(/^https?:\/\//)) url = "https://" + url;
-          lastUrl = url;
-          iframe.src = url;
+      // Safe Frame URL Swapper / Sandbox Switcher
+      function loadTargetUrl() {
+        let url = urlInput.value.trim();
+        if (!url || url === "Internal Sandbox Preview") {
+          previewFrame.style.display = "none";
+          sandboxApp.style.display = "flex";
+          return;
         }
+        
+        if (!/^https?:\/\//i.test(url)) {
+          url = 'https://' + url;
+          urlInput.value = url;
+        }
+        
+        sandboxApp.style.display = "none";
+        previewFrame.style.display = "block";
+        previewFrame.src = url;
       }
 
-      document.querySelectorAll(".preset").forEach(function (btn) {
-        btn.onclick = function () {
-          setViewport(parseInt(btn.dataset.w), parseInt(btn.dataset.h));
-        };
+      // Event Handlers
+      widthInput.addEventListener('input', () => {
+        presetBtns.forEach(b => b.classList.remove('active'));
+        updateViewport();
+      });
+      
+      heightInput.addEventListener('input', () => {
+        presetBtns.forEach(b => b.classList.remove('active'));
+        updateViewport();
+      });
+      
+      loadUrlBtn.addEventListener('click', loadTargetUrl);
+      urlInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') loadTargetUrl();
       });
 
-<<<<<<< Updated upstream
-=======
+      // Click Handling for Presets
+      presetBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          presetBtns.forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          
+          widthInput.value = btn.getAttribute('data-w');
+          heightInput.value = btn.getAttribute('data-h');
+          
+          updateViewport();
+        });
+      });
+
       // Startup Triggers
       window.addEventListener('resize', updateLiveScreenStats);
       updateLiveScreenStats();
       updateViewport();
       loadTargetUrl();
-      var screenWidth = document.getElementById("screenWidth");
-      var screenHeight = document.getElementById("screenHeight");
-      var windowWidth = document.getElementById("windowWidth");
-      var windowHeight = document.getElementById("windowHeight");
-      var devicePixelRatio = document.getElementById("devicePixelRatio");
-      var viewport = document.getElementById("viewport");
-      var viewportBar = document.getElementById("viewportBar");
-      var iframe = document.getElementById("iframe");
-      var customWidth = document.getElementById("customWidth");
-      var customHeight = document.getElementById("customHeight");
-      var applyBtn = document.getElementById("applyBtn");
-
-      var lastUrl = "https://example.com";
-
-      function updateInfo() {
-        screenWidth.textContent = screen.width;
-        screenHeight.textContent = screen.height;
-        windowWidth.textContent = window.innerWidth;
-        windowHeight.textContent = window.innerHeight;
-        devicePixelRatio.textContent = window.devicePixelRatio;
-      }
-
-      function setViewport(w, h) {
-        viewport.style.width = w + "px";
-        viewport.style.height = h + 30 + "px";
-        iframe.style.height = h + "px";
-        viewportBar.textContent = w + " x " + h;
-        customWidth.value = w;
-        customHeight.value = h;
-
-        document.querySelectorAll(".preset").forEach(function (btn) {
-          btn.classList.toggle("active", parseInt(btn.dataset.w) === w && parseInt(btn.dataset.h) === h);
-        });
-      }
-
-      function promptUrl() {
-        var url = prompt("Enter URL to test:", lastUrl);
-        if (url) {
-          if (!url.match(/^https?:\/\//)) url = "https://" + url;
-          lastUrl = url;
-          iframe.src = url;
-        }
-      }
-
-      document.querySelectorAll(".preset").forEach(function (btn) {
-        btn.onclick = function () {
-          setViewport(parseInt(btn.dataset.w), parseInt(btn.dataset.h));
-        };
-      });
-
->>>>>>> Stashed changes
-      applyBtn.onclick = function () {
-        setViewport(parseInt(customWidth.value), parseInt(customHeight.value));
-      };
-
-      viewport.onclick = promptUrl;
-
-      window.addEventListener("resize", updateInfo);
-      updateInfo();
-      setViewport(1280, 720);
     </script>
   </body>
 </html>

--- a/tools/screen-resolution-tester.html
+++ b/tools/screen-resolution-tester.html
@@ -1,3 +1,7 @@
+<<<<<<< Updated upstream
+=======
+<!DOCTYPE html>
+>>>>>>> Stashed changes
 <!doctype html>
 <html lang="en">
   <head>
@@ -6,6 +10,15 @@
     <meta name="description" content="Test your website at different screen resolutions." />
     <title>Screen Resolution Tester — One File Tools</title>
     <style>
+<<<<<<< Updated upstream
+=======
+      /* ========================================
+       Reset & Base Rules
+       ======================================== */
+    <meta name="description" content="Test your website at different screen resolutions." />
+    <title>Screen Resolution Tester — One File Tools</title>
+    <style>
+>>>>>>> Stashed changes
       *,
       *::before,
       *::after {
@@ -179,6 +192,193 @@
             <div class="info-value" id="screenHeight">-</div>
             <div class="info-label">Screen Height</div>
           </div>
+<<<<<<< Updated upstream
+=======
+        </div>
+
+        <div class="panel">
+          <h3>Device Presets</h3>
+          <div class="presets-grid">
+            <button class="preset-btn active" data-w="375" data-h="667">📱 iPhone SE</button>
+            <button class="preset-btn" data-w="393" data-h="852">📱 iPhone 15 Pro</button>
+            <button class="preset-btn" data-w="360" data-h="740">🤖 Android (Square)</button>
+            <button class="preset-btn" data-w="412" data-h="915">🤖 Android (Curved)</button>
+            <button class="preset-btn" data-w="448" data-h="992">🪐 Galaxy S24 Ultra</button>
+            <button class="preset-btn" data-w="768" data-h="1024">📟 iPad Mini</button>
+            <button class="preset-btn" data-w="820" data-h="1180">📟 iPad Air</button>
+            <button class="preset-btn" data-w="1024" data-h="768">💻 Laptop (SM)</button>
+            <button class="preset-btn" data-w="1440" data-h="900">💻 Laptop (MD)</button>
+            <button class="preset-btn" data-w="1280" data-h="720">📺 HD (720p)</button>
+            <button class="preset-btn" data-w="1920" data-h="1080">📺 Full HD (1080p)</button>
+            <button class="preset-btn" data-w="2560" data-h="1440">🖥️ QHD (2K)</button>
+            <button class="preset-btn" data-w="3840" data-h="2160">🖥️ UHD (4K)</button>
+      :root {
+        --bg: #fafafa;
+        --surface: #f1f5f9;
+        --text: #1a1a1a;
+        --muted: #64748b;
+        --border: #e2e8f0;
+        --accent: #2563eb;
+        --radius: 8px;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0a0a0a;
+          --surface: #1a1a1a;
+          --text: #e5e5e5;
+          --muted: #94a3b8;
+          --border: #334155;
+          --accent: #3b82f6;
+        }
+      }
+      body {
+        font-family: system-ui, sans-serif;
+        line-height: 1.6;
+        background: var(--bg);
+        color: var(--text);
+        min-height: 100vh;
+      }
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 2rem;
+      }
+      header {
+        text-align: center;
+        margin-bottom: 2rem;
+      }
+      header h1 {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+      }
+      header p {
+        color: var(--muted);
+      }
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        overflow: hidden;
+      }
+      .card-header {
+        font-weight: 600;
+        margin-bottom: 1rem;
+        color: var(--text);
+      }
+      .current-info {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 1rem;
+        text-align: center;
+        margin-bottom: 1.5rem;
+      }
+      .info-item {
+        background: var(--bg);
+        padding: 1rem;
+        border-radius: var(--radius);
+        overflow: hidden;
+      }
+      .info-value {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--accent);
+        overflow-wrap: break-word;
+      }
+      .info-label {
+        font-size: 0.75rem;
+        color: var(--muted);
+        text-transform: uppercase;
+      }
+      .presets {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+      }
+      .preset {
+        padding: 0.5rem 1rem;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--bg);
+        color: var(--text);
+        cursor: pointer;
+        font-size: 0.875rem;
+      }
+      .preset:hover {
+        border-color: var(--accent);
+      }
+      .preset.active {
+        background: var(--accent);
+        color: white;
+        border-color: var(--accent);
+      }
+      .viewport-wrap {
+        max-width: 100%;
+        max-height: 70vh;
+        overflow: auto;
+        border-radius: var(--radius);
+        background: var(--bg);
+      }
+      .viewport {
+        border: 2px solid var(--accent);
+        border-radius: var(--radius);
+        overflow: hidden;
+        position: relative;
+        transition: all 0.3s;
+      }
+      .viewport iframe {
+        width: 100%;
+        height: 500px;
+        border: none;
+        background: white;
+        display: block;
+      }
+      .viewport-bar {
+        position: sticky;
+        top: 0;
+        left: 0;
+        right: 0;
+        background: var(--accent);
+        color: white;
+        padding: 0.5rem;
+        font-size: 0.75rem;
+        text-align: center;
+        white-space: nowrap;
+        z-index: 1;
+      }
+      footer {
+        text-align: center;
+        padding: 2rem;
+        color: var(--muted);
+        font-size: 0.875rem;
+      }
+      footer a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>📱 Screen Resolution Tester</h1>
+        <p>Test your website at different screen sizes</p>
+      </header>
+
+      <div class="card">
+        <div class="card-header">Your Current Screen</div>
+        <div class="current-info">
+          <div class="info-item">
+            <div class="info-value" id="screenWidth">-</div>
+            <div class="info-label">Screen Width</div>
+          </div>
+          <div class="info-item">
+            <div class="info-value" id="screenHeight">-</div>
+            <div class="info-label">Screen Height</div>
+          </div>
+>>>>>>> Stashed changes
           <div class="info-item">
             <div class="info-value" id="windowWidth">-</div>
             <div class="info-label">Window Width</div>
@@ -226,6 +426,42 @@
           </div>
         </div>
       </div>
+<<<<<<< Updated upstream
+=======
+    </main>
+      <div class="card">
+        <div class="card-header">Quick Presets</div>
+        <div class="presets">
+          <button class="preset" data-w="375" data-h="667">iPhone SE</button>
+          <button class="preset" data-w="390" data-h="844">iPhone 12</button>
+          <button class="preset" data-w="414" data-h="896">iPhone 11</button>
+          <button class="preset" data-w="768" data-h="1024">iPad</button>
+          <button class="preset" data-w="1024" data-h="768">iPad Landscape</button>
+          <button class="preset" data-w="1280" data-h="720">HD</button>
+          <button class="preset" data-w="1366" data-h="768">Laptop</button>
+          <button class="preset" data-w="1920" data-h="1080">Full HD</button>
+          <button class="preset" data-w="2560" data-h="1440">2K</button>
+          <button class="preset" data-w="3840" data-h="2160">4K</button>
+        </div>
+        <div style="display: flex; gap: 1rem; margin-bottom: 1rem">
+          <div style="flex: 1">
+            <label style="font-size: 0.75rem; color: var(--muted)">Width</label>
+            <input type="number" id="customWidth" value="1280" style="width: 100%; padding: 0.5rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text)" />
+          </div>
+          <div style="flex: 1">
+            <label style="font-size: 0.75rem; color: var(--muted)">Height</label>
+            <input type="number" id="customHeight" value="720" style="width: 100%; padding: 0.5rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text)" />
+          </div>
+          <button id="applyBtn" style="align-self: flex-end; padding: 0.5rem 1rem; background: var(--accent); color: white; border: none; border-radius: 4px; cursor: pointer">Apply</button>
+        </div>
+        <div class="viewport-wrap">
+          <div class="viewport" id="viewport">
+            <div class="viewport-bar" id="viewportBar">1280 x 720</div>
+            <iframe id="iframe" src="about:blank"></iframe>
+          </div>
+        </div>
+      </div>
+>>>>>>> Stashed changes
     </div>
 
     <footer>
@@ -283,6 +519,64 @@
         };
       });
 
+<<<<<<< Updated upstream
+=======
+      // Startup Triggers
+      window.addEventListener('resize', updateLiveScreenStats);
+      updateLiveScreenStats();
+      updateViewport();
+      loadTargetUrl();
+      var screenWidth = document.getElementById("screenWidth");
+      var screenHeight = document.getElementById("screenHeight");
+      var windowWidth = document.getElementById("windowWidth");
+      var windowHeight = document.getElementById("windowHeight");
+      var devicePixelRatio = document.getElementById("devicePixelRatio");
+      var viewport = document.getElementById("viewport");
+      var viewportBar = document.getElementById("viewportBar");
+      var iframe = document.getElementById("iframe");
+      var customWidth = document.getElementById("customWidth");
+      var customHeight = document.getElementById("customHeight");
+      var applyBtn = document.getElementById("applyBtn");
+
+      var lastUrl = "https://example.com";
+
+      function updateInfo() {
+        screenWidth.textContent = screen.width;
+        screenHeight.textContent = screen.height;
+        windowWidth.textContent = window.innerWidth;
+        windowHeight.textContent = window.innerHeight;
+        devicePixelRatio.textContent = window.devicePixelRatio;
+      }
+
+      function setViewport(w, h) {
+        viewport.style.width = w + "px";
+        viewport.style.height = h + 30 + "px";
+        iframe.style.height = h + "px";
+        viewportBar.textContent = w + " x " + h;
+        customWidth.value = w;
+        customHeight.value = h;
+
+        document.querySelectorAll(".preset").forEach(function (btn) {
+          btn.classList.toggle("active", parseInt(btn.dataset.w) === w && parseInt(btn.dataset.h) === h);
+        });
+      }
+
+      function promptUrl() {
+        var url = prompt("Enter URL to test:", lastUrl);
+        if (url) {
+          if (!url.match(/^https?:\/\//)) url = "https://" + url;
+          lastUrl = url;
+          iframe.src = url;
+        }
+      }
+
+      document.querySelectorAll(".preset").forEach(function (btn) {
+        btn.onclick = function () {
+          setViewport(parseInt(btn.dataset.w), parseInt(btn.dataset.h));
+        };
+      });
+
+>>>>>>> Stashed changes
       applyBtn.onclick = function () {
         setViewport(parseInt(customWidth.value), parseInt(customHeight.value));
       };


### PR DESCRIPTION
## What does this PR do?
Introduces a fully self-contained, responsive client-side Screen Resolution Tester utility. This tool enables developers and UI/UX designers to evaluate web responsiveness, compute aspect ratios, and test custom viewport scaling properties seamlessly. 

Features included:
- Automated local system hardware screen & available workspace parameter metrics detection.
- 13 high-fidelity preset viewport configurations spanning Apple iOS ecosystems, standard & curved bezel-less Android viewports (including Samsung Galaxy S24 Ultra matrices), laptops, and high-definition televisions (720p, 1080p, 2K, 4K).
- Custom numeric inputs to toggle fine-grained width and height constraints.
- Integrated Canvas Core Sandbox environment containing full metric evaluations to prevent canvas breakage on cross-origin iframe security headers.

Closes #274

## Type of Change

- [x] New tool
- [ ] Enhancement to existing tool
- [ ] Bug fix
- [ ] Documentation update
- [ ] Build system / infrastructure

## Screenshot 
<img width="1599" height="802" alt="screen-resolution-tester" src="https://github.com/user-attachments/assets/9574b156-15c7-4315-9f08-c4e82830f02b" />
<img width="1599" height="821" alt="Screenshot 2026-07-14 183247" src="https://github.com/user-attachments/assets/4e1e8738-bdf3-41d2-9aeb-216a2ccadaa6" />
<img width="1599" height="816" alt="Screenshot 2026-07-14 183237" src="https://github.com/user-attachments/assets/8b038660-1fa4-4449-95ff-ba3ee37fd3e5" />


## Checklist
- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser

### For new tools:
- [x] The tool is a single self-contained `.html` file in the `tools/` folder
- [x] The filename is kebab-case (e.g. `json-formatter.html`)
- [x] I added an entry to `data/tools.json` with all required fields
- [x] I added a screenshot as `tools/<tool-name>.png` next to the HTML file
- [x] No JS frameworks (React, Vue, Angular, etc.) or heavy UI libraries (Bootstrap JS, jQuery, etc.)
- [x] CDN links for lightweight libraries and fonts are fine — no copy-pasting library source code inline
- [x] I ran `node scripts/sort-norm.js data/tools.json` to sort and normalize the tools registry
- [x] I ran `node scripts/build.js` and verified the landing page renders correctly