### PR TITLE
fix: eliminate duplicate CSS classes in git bisect detective lineup [BotFix Not a part of SSoC]

### DIFF
--- a/quests/git-bisect-detective.html
+++ b/quests/git-bisect-detective.html
@@ -471,14 +471,15 @@
 
         const lineup = g.commits.map((c) => {
           let cls = "suspect";
-          if (c.index <= g.low || c.index >= g.high) {
-            if (c.index < g.low || (c.index === g.low && c.index !== 0 && c.status === "good")) cls += " eliminated-good";
-          }
-          if (c.index < g.low) cls += " eliminated-good";
-          else if (c.index > g.high) cls += " eliminated-bad";
-          else if (c.index === g.low) cls += " eliminated-good";
-          else if (c.index === g.high) cls += " eliminated-bad";
-          else {
+          if (c.index < g.low) {
+            cls += " eliminated-good";
+          } else if (c.index > g.high) {
+            cls += " eliminated-bad";
+          } else if (c.index === g.low) {
+            cls += " eliminated-good";
+          } else if (c.index === g.high) {
+            cls += " eliminated-bad";
+          } else {
             cls += " active";
             if (c.index === mid) cls += " prime";
           }


### PR DESCRIPTION
# fix: eliminate duplicate CSS classes in git bisect detective lineup

## Summary

Fixed duplicate CSS classes being applied to suspects in the Git Bisect Detective lineup. The issue was in the lineup rendering logic where two separate conditional checks were both adding the 'eliminated-good' class when c.index === g.low, resulting in duplicate classes in the HTML.

Fixed by consolidating the conditional logic into a single if-else if structure that properly handles the boundary conditions without duplication.

Fixes #539

## Changes

- Consolidated duplicate conditional checks in the lineup rendering logic (lines 472-484)
- Changed from multiple independent if statements to if-else if structure
- Ensures each suspect gets exactly one appropriate class based on their position relative to the search bounds

## Testing

- Verified the fix by examining the HTML output in browser dev tools
- Confirmed that suspects now have only one appropriate class (eliminated-good, eliminated-bad, active, or prime)
- Tested across different difficulty levels to ensure the fix works for various numbers of suspects
- Manual verification that the game logic still functions correctly with the fixed class assignments

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
