### PR TITLE
fix: require correct prediction to clear predict-type chambers

### DIFF
--- a/quests/closure-escape-room.html
+++ b/quests/closure-escape-room.html
@@ -1408,7 +1408,8 @@ function renderRoom(room){
         if (!predictedRight) mascotSay(mascotPick(MASCOT_WRONG_PREDICT), 5000);
       }
 
-      var solvedNow = !result.error && checkSolved(result.logs);
+      var predictedRight = room.type !== "predict" || (chosenIndex === room.answerIndex);
+      var solvedNow = predictedRight && !result.error && checkSolved(result.logs);
       if (solvedNow){
         var alreadySolved = !!state.solved[room.id];
         var hintsCount = (state.hintsUsed[room.id] || []).length;


### PR DESCRIPTION
Closes #536 
### Description
**Affected file:** `quests/closure-escape-room.html`

**Problem:**
Prediction chambers (e.g. "Chamber 1: The Lexical Corridor") could be cleared even when the user selected an incorrect prediction option. Because `solvedNow` only checked that the sandboxed code executed without errors and matched the expected log output — not that the user's selected option was correct — players could advance through every predict room by clicking "Run code" regardless of their answer.

**Root cause:**
```js
// Before — prediction correctness not checked
var solvedNow = !result.error && checkSolved(result.logs);
```

**Fix:**
Added a `predictedRight` guard that short-circuits `solvedNow` for `predict`-type rooms unless `chosenIndex === room.answerIndex`:
```js
// After
var predictedRight = room.type !== "predict" || (chosenIndex === room.answerIndex);
var solvedNow = predictedRight && !result.error && checkSolved(result.logs);
```

**Testing:**
1. Open `quests/closure-escape-room.html`
2. Select an incorrect option in Chamber 1 → Run code → Chamber should **not** clear
3. Select the correct option → Run code → Chamber clears as expected
