### PR TITLE
fix: escape user data in API Response Mocker to prevent XSS

### DIFF
--- a/tools/api-response-mocker.html
+++ b/tools/api-response-mocker.html
@@ -424,6 +424,18 @@
       }
 
       /**
+       * Escapes a string for safe insertion into HTML context.
+       */
+      function escHtml(str) {
+        return String(str)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
+
+      /**
        * Validates and auto-formats the JSON input with strict 2-space indentation.
        */
       function formatAndSortInput() {
@@ -468,7 +480,7 @@
             <div class="mock-header">
               <div style="display: flex; align-items: center; gap: 0.75rem;">
                 <span class="method-badge method-${mock.method}">${mock.method}</span>
-                <span class="mock-path">${mock.path}</span>
+                <span class="mock-path">${escHtml(mock.path)}</span>
               </div>
               <div class="status-badge">
                 <div class="status-indicator ${statusClass}"></div>
@@ -508,16 +520,16 @@
         term.classList.add("active");
 
         const timestamp = new Date().toISOString();
-        term.innerHTML = `<span class="term-muted">[${timestamp}]</span> <span class="term-info">INIT</span> Fetching ${mock.path} <span class="spinner">⚙</span>`;
+        term.innerHTML = `<span class="term-muted">[${timestamp}]</span> <span class="term-info">INIT</span> Fetching ${escHtml(mock.path)} <span class="spinner">⚙</span>`;
 
         setTimeout(() => {
           const size = new Blob([mock.response]).size;
           term.innerHTML = `
-<span class="term-muted">[${timestamp}]</span> <span class="term-info">INIT</span> Fetching ${mock.path}
+<span class="term-muted">[${timestamp}]</span> <span class="term-info">INIT</span> Fetching ${escHtml(mock.path)}
 <span class="term-muted">[${new Date().toISOString()}]</span> <span class="term-success">DONE</span> ${mock.status} OK (${mock.delay}ms)
 <span class="term-muted">Content-Type: application/json | Content-Length: ${size}</span>
 
-${mock.response}
+${escHtml(mock.response)}
           `;
         }, mock.delay);
       };


### PR DESCRIPTION
Fixes #537 
### Description
**Affected file:** `tools/api-response-mocker.html`

**Problem:**
`mock.path` and `mock.response` were interpolated directly into `innerHTML` template literals without any HTML sanitisation. A payload like `/<img src=x onerror=alert(1)>` as a mock path would execute immediately when the mock list was rendered or when "Run Request" was clicked. Because mocks are persisted in `localStorage`, the XSS also survived page reloads.

**Root cause:**
```js
// Before — raw user input in innerHTML
item.innerHTML = `...<span class="mock-path">${mock.path}</span>...`;
term.innerHTML = `... Fetching ${mock.path} ...`;
// response also unescaped
${mock.response}
```

**Fix:**
Added an `escHtml()` helper that encodes `&`, `<`, `>`, `"`, and `'` and applied it to all three injection points:
```js
function escHtml(str) {
  return String(str)
    .replace(/&/g, "&amp;")
    .replace(/</g, "&lt;")
    .replace(/>/g, "&gt;")
    .replace(/"/g, "&quot;")
    .replace(/'/g, "&#39;");
}

// After — all user data escaped
<span class="mock-path">${escHtml(mock.path)}</span>
Fetching ${escHtml(mock.path)}
${escHtml(mock.response)}
```

**Testing:**
1. Open `tools/api-response-mocker.html`
2. Set path to `/<img src=x onerror=alert(1)>` → Save → Path renders as literal text, no alert fires
3. Set JSON payload to `{"x":"<script>alert(1)</script>"}` → Run Request → Output shown as escaped text