### PR TITLE
fix: copy live textarea value instead of stale entry.value in LocalStorage Explorer

### DIFF
--- a/tools/localstorage-explorer.html
+++ b/tools/localstorage-explorer.html
@@ -583,7 +583,7 @@ Built for One File Tools.
         copyValueBtn.type = "button";
         copyValueBtn.className = "icon-btn-sm";
         copyValueBtn.textContent = "Copy value";
-        copyValueBtn.addEventListener("click", () => copyText(entry.value, "Value copied!"));
+        copyValueBtn.addEventListener("click", () => copyText(textarea.value, "Value copied!"));
 
         const deleteBtn = document.createElement("button");
         deleteBtn.type = "button";


### PR DESCRIPTION
Closes #538
### Description
**Affected file:** `tools/localstorage-explorer.html`

**Problem:**
When a user edits a key's value in the textarea and then clicks "Copy value" before saving, the button copies the original value from localStorage (`entry.value`) rather than the current content of the textarea (`textarea.value`). This is confusing and means users cannot copy unsaved edits.

**Root cause:**
```js
// Before — copies the original stored value, ignoring textarea edits
copyValueBtn.addEventListener("click", () => copyText(entry.value, "Value copied!"));
```

**Fix:**
Changed the event handler to read from `textarea.value` so the live, possibly-unsaved content is always what gets copied:
```js
// After — copies whatever is currently in the textarea
copyValueBtn.addEventListener("click", () => copyText(textarea.value, "Value copied!"));
```

**Testing:**
1. Open `tools/localstorage-explorer.html`
2. Select any key and modify its value in the textarea
3. Click "Copy value" **without** saving
4. Paste → edited text is copied ✅
