### PR TITLE
Improve: canonical-url-checker - SEO score, chain/self-reference checks, JSON export

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -441,7 +441,7 @@
       "id": "canonical-url-checker",
       "name": "Canonical URL Checker",
       "shortDescription": "Analyze HTML to verify canonical URL implementation and identify common SEO issues.",
-      "longDescription": "## Canonical URL Checker\n\nAnalyze pasted HTML to detect missing, duplicate, invalid, relative, or incorrectly placed canonical tags.\n\n### Features\n- Detects missing canonical tags\n- Identifies duplicate canonical tags\n- Validates absolute canonical URLs\n- Detects relative or empty canonical URLs\n- Checks if the canonical tag is placed inside the <head> section\n- Provides SEO recommendations\n- Copy analysis report\n- Download report as a text file\n- Works completely offline",
+      "longDescription": "## Canonical URL Checker\n\nAnalyze pasted HTML to detect missing, duplicate, invalid, relative, or incorrectly placed canonical tags, with deeper SEO validation and actionable recommendations.\n\n### Features\n- Detects missing, duplicate, invalid, relative, or incorrectly placed canonical tags\n- Optional page URL field to check for self-referencing canonicals and canonical chains\n- Highlights HTTP/HTTPS protocol inconsistencies between the page and its canonical\n- Calculates an overall SEO health score with a pass/fail breakdown\n- Displays an actionable recommendation for every issue found\n- Copy the report or export it as a .txt or .json file\n- Fully responsive and accessible layout\n- Works completely offline",
       "category": "web-seo",
       "tags": [
         "canonical",
@@ -449,6 +449,7 @@
         "meta",
         "search-engine-optimization",
         "seo",
+        "seo-score",
         "url",
         "validation",
         "web"

--- a/tools/canonical-url-checker.html
+++ b/tools/canonical-url-checker.html
@@ -144,6 +144,10 @@
         color: #991b1b;
       }
 
+      .result textarea {
+        height: 120px;
+      }
+
       footer {
         margin-top: 2rem;
         text-align: center;
@@ -171,142 +175,6 @@
           grid-template-columns: 1fr;
         }
       }
-
-      /* ========================================
-       SEO Health Score
-       ======================================== */
-      .score-card {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        padding: 1rem;
-        border-radius: 10px;
-        margin-bottom: 1rem;
-        background: #f3f4f6;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .score-card {
-          background: #2a2a2a;
-        }
-      }
-
-      .score-ring {
-        width: 56px;
-        height: 56px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: 700;
-        font-size: 1.1rem;
-        flex-shrink: 0;
-        color: white;
-      }
-
-      .score-ring.good {
-        background: #16a34a;
-      }
-
-      .score-ring.fair {
-        background: #d97706;
-      }
-
-      .score-ring.poor {
-        background: #dc2626;
-      }
-
-      .score-label {
-        font-weight: 600;
-      }
-
-      .score-sub {
-        font-size: 0.85rem;
-        color: #666;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .score-sub {
-          color: #aaa;
-        }
-      }
-
-      /* ========================================
-       Issue List
-       ======================================== */
-      .issue-list {
-        list-style: none;
-        margin: 0 0 1.5rem;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.6rem;
-      }
-
-      .issue {
-        padding: 0.75rem;
-        border-radius: 8px;
-        border-left: 4px solid #999;
-        background: #f9fafb;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .issue {
-          background: #1e1e1e;
-        }
-      }
-
-      .issue.error {
-        border-left-color: #dc2626;
-      }
-
-      .issue.warning {
-        border-left-color: #d97706;
-      }
-
-      .issue.success {
-        border-left-color: #16a34a;
-      }
-
-      .issue-title {
-        font-weight: 600;
-        margin-bottom: 0.25rem;
-      }
-
-      .issue-rec {
-        font-size: 0.9rem;
-        color: #555;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .issue-rec {
-          color: #bbb;
-        }
-      }
-
-      .optional-field {
-        margin-top: 1rem;
-        padding-top: 1rem;
-        border-top: 1px dashed #ccc;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .optional-field {
-          border-top-color: #444;
-        }
-      }
-
-      .helper-text {
-        font-size: 0.85rem;
-        color: #666;
-        margin-top: 0.25rem;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .helper-text {
-          color: #999;
-        }
-      }
     </style>
   </head>
   <body>
@@ -323,13 +191,7 @@
 
           <label for="htmlInput">Paste HTML Source</label>
 
-          <textarea id="htmlInput" rows="16" placeholder="Paste your HTML source or <head> section here..."></textarea>
-
-          <div class="optional-field">
-            <label for="pageUrl">Page URL <span style="font-weight: 400">(optional)</span></label>
-            <input id="pageUrl" type="text" placeholder="https://example.com/current-page" autocomplete="off" />
-            <p class="helper-text">Provide the URL this HTML was fetched from to check for a self-referencing canonical and HTTP/HTTPS consistency.</p>
-          </div>
+          <textarea id="htmlInput" rows="18" placeholder="Paste your HTML source or <head> section here..."></textarea>
 
           <div class="buttons">
             <button id="exampleBtn">Load Example</button>
@@ -344,25 +206,20 @@
 
           <div id="statusCard" class="status neutral">Waiting for analysis...</div>
 
-          <div id="scoreCard" class="score-card" style="display: none">
-            <div id="scoreRing" class="score-ring good">0</div>
-            <div>
-              <div class="score-label">SEO Health Score</div>
-              <div class="score-sub" id="scoreSub">0 of 0 checks passed</div>
-            </div>
-          </div>
-
-          <ul id="issueList" class="issue-list"></ul>
-
           <div class="result">
             <label>Canonical URL</label>
             <input id="canonicalUrl" readonly placeholder="No canonical URL found" />
+
+            <label>Status</label>
+            <input id="statusText" readonly placeholder="Waiting..." />
+
+            <label>Recommendations</label>
+            <textarea id="recommendation" rows="7" readonly></textarea>
           </div>
 
           <div class="buttons">
             <button id="copyBtn">Copy Report</button>
-            <button id="downloadBtn">Download Report (.txt)</button>
-            <button id="downloadJsonBtn">Download Report (.json)</button>
+            <button id="downloadBtn">Download Report</button>
           </div>
         </section>
       </div>
@@ -374,7 +231,6 @@
 
     <script>
       const htmlInput = document.getElementById("htmlInput");
-      const pageUrlInput = document.getElementById("pageUrl");
 
       const analyzeBtn = document.getElementById("analyzeBtn");
       const exampleBtn = document.getElementById("exampleBtn");
@@ -382,220 +238,159 @@
 
       const copyBtn = document.getElementById("copyBtn");
       const downloadBtn = document.getElementById("downloadBtn");
-      const downloadJsonBtn = document.getElementById("downloadJsonBtn");
 
       const canonicalUrl = document.getElementById("canonicalUrl");
+      const statusText = document.getElementById("statusText");
+      const recommendation = document.getElementById("recommendation");
+
       const statusCard = document.getElementById("statusCard");
-      const scoreCard = document.getElementById("scoreCard");
-      const scoreRing = document.getElementById("scoreRing");
-      const scoreSub = document.getElementById("scoreSub");
-      const issueList = document.getElementById("issueList");
+      function analyzeHTML() {
+        const html = htmlInput.value.trim();
+        if (!html) {
+          statusCard.className = "status warning";
+          statusCard.textContent = "Please paste HTML source.";
 
-      // Holds the most recently generated report so Copy/Download stay in sync.
-      let lastReport = null;
-
-      /**
-       * Runs every canonical-tag check against the parsed document and
-       * returns a structured report: a list of issues (each with a
-       * severity, title, and recommendation) plus the resolved canonical
-       * URL and an overall SEO health score.
-       */
-      function buildReport(html, pageUrl) {
-        const issues = [];
-        const addIssue = (severity, title, rec) => issues.push({ severity, title, recommendation: rec });
+          canonicalUrl.value = "";
+          statusText.value = "No HTML Provided";
+          recommendation.value = "Paste a webpage's HTML source to analyze its canonical tag.";
+          copyBtn.disabled = true;
+          downloadBtn.disabled = true;
+          return;
+        }
+        copyBtn.disabled = false;
+        downloadBtn.disabled = false;
 
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, "text/html");
 
-        const canonicalTags = Array.from(doc.querySelectorAll('link[rel="canonical"]'));
-        const headCanonical = Array.from(doc.head.querySelectorAll('link[rel="canonical"]'));
+        const canonicalTags = doc.querySelectorAll('link[rel="canonical"]');
+        const headCanonical = doc.head.querySelectorAll('link[rel="canonical"]');
 
-        let resolvedHref = "";
-
-        // --- Placement: outside <head> ---
         if (canonicalTags.length && headCanonical.length === 0) {
-          addIssue("error", "Canonical tag outside <head>", "Move the canonical tag inside the <head> section. Canonical tags outside <head> are ignored by most search engines.");
-        }
-
-        // --- Missing ---
-        if (canonicalTags.length === 0) {
-          addIssue("error", "No canonical tag found", 'Add a <link rel="canonical" href="..."> tag inside the <head> section so search engines know the preferred URL for this page.');
-        }
-
-        // --- Multiple canonical tags ---
-        if (canonicalTags.length > 1) {
-          const hrefs = canonicalTags.map((t) => t.getAttribute("href") || "(empty)");
-          addIssue("error", `Multiple canonical tags found (${canonicalTags.length})`, `Only one canonical tag should exist per page. Found: ${hrefs.join(", ")}. Remove all but one.`);
-        }
-
-        if (canonicalTags.length >= 1) {
-          const href = (canonicalTags[0].getAttribute("href") || "").trim();
-          resolvedHref = href;
-
-          if (!href) {
-            addIssue("error", "Empty canonical URL", "The canonical tag exists but its href attribute is empty. Provide a full, absolute URL.");
-          } else if (!/^https?:\/\//i.test(href)) {
-            addIssue("warning", "Relative canonical URL", `Use an absolute URL (including protocol and domain) instead of a relative canonical URL like "${href}". Relative canonicals are more error-prone and not recommended by Google.`);
-          } else {
-            let parsedHref = null;
-            try {
-              parsedHref = new URL(href);
-            } catch {
-              addIssue("error", "Invalid canonical URL", `"${href}" is not a valid absolute URL. Double-check for typos or malformed syntax.`);
-            }
-
-            if (parsedHref) {
-              // --- Canonical chains / self-reference vs a known page URL ---
-              let parsedPage = null;
-              if (pageUrl) {
-                try {
-                  parsedPage = new URL(pageUrl);
-                } catch {
-                  addIssue("warning", "Page URL is not a valid absolute URL", "The optional page URL you provided could not be parsed. Self-reference and protocol checks were skipped.");
-                }
-              }
-
-              if (parsedPage) {
-                const sameUrl = parsedHref.href.replace(/\/$/, "") === parsedPage.href.replace(/\/$/, "");
-                if (!sameUrl) {
-                  addIssue("warning", "Canonical does not self-reference the page URL", `The page at "${parsedPage.href}" declares a canonical pointing to "${parsedHref.href}". This may be intentional (e.g. for duplicate/paginated content) but can also indicate a canonical chain — verify the target page's own canonical also points to itself.`);
-                } else {
-                  addIssue("success", "Canonical self-references the page URL", "The canonical URL matches the page it was found on, which is the expected pattern for a page's primary canonical.");
-                }
-
-                // --- HTTP/HTTPS inconsistency ---
-                if (parsedHref.protocol !== parsedPage.protocol) {
-                  addIssue("warning", "HTTP/HTTPS protocol mismatch", `The page is served over "${parsedPage.protocol}" but the canonical URL uses "${parsedHref.protocol}". Canonical URLs should use the same protocol as the live site (prefer HTTPS).`);
-                }
-              }
-
-              if (parsedHref.protocol !== "https:") {
-                addIssue("warning", "Canonical URL is not HTTPS", "Canonical URLs should point to the HTTPS version of a page when your site supports HTTPS.");
-              }
-
-              if (issues.every((i) => i.severity !== "error")) {
-                addIssue("success", "Canonical tag is well-formed", "Found exactly one canonical tag inside <head>, with a valid absolute URL.");
-              }
-            }
-          }
-        }
-
-        const errorCount = issues.filter((i) => i.severity === "error").length;
-        const warningCount = issues.filter((i) => i.severity === "warning").length;
-        const totalChecks = issues.length || 1;
-        const passedChecks = issues.filter((i) => i.severity === "success").length;
-
-        // Score: start at 100, subtract per error/warning, floor at 0.
-        let score = 100 - errorCount * 30 - warningCount * 12;
-        score = Math.max(0, Math.min(100, score));
-
-        return {
-          canonicalUrl: resolvedHref,
-          issues,
-          score,
-          errorCount,
-          warningCount,
-          totalChecks,
-          passedChecks,
-          overall: errorCount > 0 ? "error" : warningCount > 0 ? "warning" : "success"
-        };
-      }
-
-      function scoreTier(score) {
-        if (score >= 80) return "good";
-        if (score >= 50) return "fair";
-        return "poor";
-      }
-
-      function renderReport(report) {
-        canonicalUrl.value = report.canonicalUrl || "";
-
-        if (report.overall === "success") {
-          statusCard.className = "status success";
-          statusCard.textContent = "Valid Canonical Implementation";
-        } else if (report.overall === "warning") {
           statusCard.className = "status warning";
-          statusCard.textContent = `${report.warningCount} Warning${report.warningCount === 1 ? "" : "s"} Found`;
-        } else {
-          statusCard.className = "status warning";
-          statusCard.textContent = `${report.errorCount} Issue${report.errorCount === 1 ? "" : "s"} Found`;
-        }
+          statusCard.textContent = "Canonical Tag Outside <head>";
 
-        scoreCard.style.display = "flex";
-        scoreRing.textContent = String(report.score);
-        scoreRing.className = "score-ring " + scoreTier(report.score);
-        scoreSub.textContent = `${report.passedChecks} of ${report.totalChecks} checks passed`;
+          canonicalUrl.value = canonicalTags[0].getAttribute("href") || "";
 
-        issueList.innerHTML = report.issues
-          .map(
-            (issue) => `
-          <li class="issue ${issue.severity}">
-            <div class="issue-title">${issue.severity === "success" ? "✔" : issue.severity === "error" ? "✖" : "⚠"} ${escapeHtml(issue.title)}</div>
-            <div class="issue-rec">${escapeHtml(issue.recommendation)}</div>
-          </li>`
-          )
-          .join("");
-      }
+          statusText.value = "Incorrect Placement";
 
-      function escapeHtml(str) {
-        return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-      }
+          recommendation.value = "Move the canonical tag inside the <head> section.";
 
-      function resetResultUI(message) {
-        statusCard.className = "status neutral";
-        statusCard.textContent = message;
-        canonicalUrl.value = "";
-        scoreCard.style.display = "none";
-        issueList.innerHTML = "";
-        lastReport = null;
-        copyBtn.disabled = true;
-        downloadBtn.disabled = true;
-        downloadJsonBtn.disabled = true;
-      }
-
-      function analyzeHTML() {
-        const html = htmlInput.value.trim();
-        if (!html) {
-          resetResultUI("Please paste HTML source.");
           return;
         }
 
-        const pageUrl = pageUrlInput.value.trim();
-        const report = buildReport(html, pageUrl);
-        report.pageUrl = pageUrl || null;
-        lastReport = report;
+        // Missing canonical
+        if (canonicalTags.length === 0) {
+          statusCard.className = "status warning";
+          statusCard.textContent = "No Canonical Tag Found";
 
-        renderReport(report);
-        copyBtn.disabled = false;
-        downloadBtn.disabled = false;
-        downloadJsonBtn.disabled = false;
+          canonicalUrl.value = "";
+          statusText.value = "Missing";
+          recommendation.value = 'Add a <link rel="canonical"> tag inside the <head> section.';
+
+          return;
+        }
+
+        // Multiple canonicals
+        if (canonicalTags.length > 1) {
+          statusCard.className = "status warning";
+          statusCard.textContent = "Multiple Canonical Tags";
+
+          canonicalUrl.value = "";
+          statusText.value = "Conflict";
+          recommendation.value = "Only one canonical tag should exist on a webpage.";
+
+          return;
+        }
+
+        const href = canonicalTags[0].getAttribute("href");
+        // Empty href
+        if (!href || href.trim() === "") {
+          statusCard.className = "status warning";
+          statusCard.textContent = "Empty Canonical URL";
+
+          canonicalUrl.value = "";
+          statusText.value = "Invalid";
+          recommendation.value = "The canonical tag exists but its href attribute is empty.";
+
+          return;
+        }
+
+        let validURL = true;
+
+        // Relative URL
+        if (!/^https?:\/\//i.test(href)) {
+          statusCard.className = "status warning";
+          statusCard.textContent = "Relative Canonical URL";
+
+          canonicalUrl.value = href;
+          statusText.value = "Relative URL";
+          recommendation.value = "Use an absolute URL instead of a relative canonical URL.";
+
+          return;
+        }
+
+        try {
+          new URL(href);
+        } catch {
+          validURL = false;
+        }
+
+        if (!validURL) {
+          statusCard.className = "status warning";
+          statusCard.textContent = "Invalid Canonical URL";
+
+          canonicalUrl.value = href;
+          statusText.value = "Invalid URL";
+
+          recommendation.value = "The canonical URL is not a valid absolute URL.";
+
+          return;
+        }
+
+        // Valid
+        statusCard.className = "status success";
+        statusCard.textContent = "Valid Canonical URL";
+
+        canonicalUrl.value = href;
+        statusText.value = "Valid";
+        recommendation.value = `✔ Canonical tag found.
+
+✔ Uses an absolute URL.
+
+✔ Only one canonical tag exists.
+
+✔ Appears correctly implemented for SEO.`;
       }
-
-      function buildTextReport(report) {
-        const lines = ["Canonical URL Checker Report", "", `SEO Health Score: ${report.score}/100 (${report.passedChecks}/${report.totalChecks} checks passed)`, `Canonical URL: ${report.canonicalUrl || "Not Found"}`, report.pageUrl ? `Page URL: ${report.pageUrl}` : null, "", "Issues & Recommendations:"].filter(Boolean);
-
-        report.issues.forEach((issue) => {
-          lines.push(`- [${issue.severity.toUpperCase()}] ${issue.title}`);
-          lines.push(`  ${issue.recommendation}`);
-        });
-
-        return lines.join("\n");
-      }
-
       analyzeBtn.addEventListener("click", analyzeHTML);
       copyBtn.disabled = true;
       downloadBtn.disabled = true;
-      downloadJsonBtn.disabled = true;
-
       resetBtn.addEventListener("click", () => {
         htmlInput.value = "";
-        pageUrlInput.value = "";
-        resetResultUI("Waiting for analysis...");
-      });
 
+        canonicalUrl.value = "";
+
+        statusText.value = "Waiting...";
+
+        recommendation.value = "Paste HTML and click Analyze to check the canonical tag.";
+
+        statusCard.className = "status neutral";
+
+        statusCard.textContent = "Waiting for analysis...";
+        copyBtn.disabled = true;
+        downloadBtn.disabled = true;
+      });
       copyBtn.addEventListener("click", async () => {
-        if (!lastReport) return;
-        const report = buildTextReport(lastReport);
+        const report = `Canonical URL Checker Report
+
+Status: ${statusText.value}
+
+Canonical URL:
+${canonicalUrl.value || "Not Found"}
+
+Recommendations:
+${recommendation.value}
+`;
 
         try {
           await navigator.clipboard.writeText(report);
@@ -611,43 +406,35 @@
             copyBtn.style.backgroundColor = originalColor || "#1d9bf0";
           }, 2000);
         } catch {
-          // Clipboard API unavailable or blocked (e.g. insecure context) —
-          // fail gracefully without breaking the rest of the tool.
-          alert("Failed to copy report. Your browser may have blocked clipboard access.");
+          alert("Failed to copy report.");
         }
       });
-
       downloadBtn.addEventListener("click", () => {
-        if (!lastReport) return;
-        const report = buildTextReport(lastReport);
+        const report = `Canonical URL Checker Report
 
-        try {
-          const blob = new Blob([report], { type: "text/plain" });
-          const link = document.createElement("a");
-          link.href = URL.createObjectURL(blob);
-          link.download = "canonical-url-report.txt";
-          link.click();
-          URL.revokeObjectURL(link.href);
-        } catch {
-          alert("Failed to download the report in this browser.");
-        }
+Status: ${statusText.value}
+
+Canonical URL:
+${canonicalUrl.value || "Not Found"}
+
+Recommendations:
+${recommendation.value}
+`;
+
+        const blob = new Blob([report], {
+          type: "text/plain"
+        });
+
+        const link = document.createElement("a");
+
+        link.href = URL.createObjectURL(blob);
+
+        link.download = "canonical-url-report.txt";
+
+        link.click();
+
+        URL.revokeObjectURL(link.href);
       });
-
-      downloadJsonBtn.addEventListener("click", () => {
-        if (!lastReport) return;
-
-        try {
-          const blob = new Blob([JSON.stringify(lastReport, null, 2)], { type: "application/json" });
-          const link = document.createElement("a");
-          link.href = URL.createObjectURL(blob);
-          link.download = "canonical-url-report.json";
-          link.click();
-          URL.revokeObjectURL(link.href);
-        } catch {
-          alert("Failed to download the report in this browser.");
-        }
-      });
-
       exampleBtn.addEventListener("click", () => {
         htmlInput.value = `<!DOCTYPE html>
 <html>
@@ -665,7 +452,6 @@
 
 </body>
 </html>`;
-        pageUrlInput.value = "https://example.com/page";
 
         analyzeHTML();
       });

--- a/tools/canonical-url-checker.html
+++ b/tools/canonical-url-checker.html
@@ -144,10 +144,6 @@
         color: #991b1b;
       }
 
-      .result textarea {
-        height: 120px;
-      }
-
       footer {
         margin-top: 2rem;
         text-align: center;
@@ -175,6 +171,142 @@
           grid-template-columns: 1fr;
         }
       }
+
+      /* ========================================
+       SEO Health Score
+       ======================================== */
+      .score-card {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+        border-radius: 10px;
+        margin-bottom: 1rem;
+        background: #f3f4f6;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .score-card {
+          background: #2a2a2a;
+        }
+      }
+
+      .score-ring {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 1.1rem;
+        flex-shrink: 0;
+        color: white;
+      }
+
+      .score-ring.good {
+        background: #16a34a;
+      }
+
+      .score-ring.fair {
+        background: #d97706;
+      }
+
+      .score-ring.poor {
+        background: #dc2626;
+      }
+
+      .score-label {
+        font-weight: 600;
+      }
+
+      .score-sub {
+        font-size: 0.85rem;
+        color: #666;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .score-sub {
+          color: #aaa;
+        }
+      }
+
+      /* ========================================
+       Issue List
+       ======================================== */
+      .issue-list {
+        list-style: none;
+        margin: 0 0 1.5rem;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+      }
+
+      .issue {
+        padding: 0.75rem;
+        border-radius: 8px;
+        border-left: 4px solid #999;
+        background: #f9fafb;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .issue {
+          background: #1e1e1e;
+        }
+      }
+
+      .issue.error {
+        border-left-color: #dc2626;
+      }
+
+      .issue.warning {
+        border-left-color: #d97706;
+      }
+
+      .issue.success {
+        border-left-color: #16a34a;
+      }
+
+      .issue-title {
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+      }
+
+      .issue-rec {
+        font-size: 0.9rem;
+        color: #555;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .issue-rec {
+          color: #bbb;
+        }
+      }
+
+      .optional-field {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px dashed #ccc;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .optional-field {
+          border-top-color: #444;
+        }
+      }
+
+      .helper-text {
+        font-size: 0.85rem;
+        color: #666;
+        margin-top: 0.25rem;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .helper-text {
+          color: #999;
+        }
+      }
     </style>
   </head>
   <body>
@@ -191,7 +323,13 @@
 
           <label for="htmlInput">Paste HTML Source</label>
 
-          <textarea id="htmlInput" rows="18" placeholder="Paste your HTML source or <head> section here..."></textarea>
+          <textarea id="htmlInput" rows="16" placeholder="Paste your HTML source or <head> section here..."></textarea>
+
+          <div class="optional-field">
+            <label for="pageUrl">Page URL <span style="font-weight: 400">(optional)</span></label>
+            <input id="pageUrl" type="text" placeholder="https://example.com/current-page" autocomplete="off" />
+            <p class="helper-text">Provide the URL this HTML was fetched from to check for a self-referencing canonical and HTTP/HTTPS consistency.</p>
+          </div>
 
           <div class="buttons">
             <button id="exampleBtn">Load Example</button>
@@ -206,20 +344,25 @@
 
           <div id="statusCard" class="status neutral">Waiting for analysis...</div>
 
+          <div id="scoreCard" class="score-card" style="display: none">
+            <div id="scoreRing" class="score-ring good">0</div>
+            <div>
+              <div class="score-label">SEO Health Score</div>
+              <div class="score-sub" id="scoreSub">0 of 0 checks passed</div>
+            </div>
+          </div>
+
+          <ul id="issueList" class="issue-list"></ul>
+
           <div class="result">
             <label>Canonical URL</label>
             <input id="canonicalUrl" readonly placeholder="No canonical URL found" />
-
-            <label>Status</label>
-            <input id="statusText" readonly placeholder="Waiting..." />
-
-            <label>Recommendations</label>
-            <textarea id="recommendation" rows="7" readonly></textarea>
           </div>
 
           <div class="buttons">
             <button id="copyBtn">Copy Report</button>
-            <button id="downloadBtn">Download Report</button>
+            <button id="downloadBtn">Download Report (.txt)</button>
+            <button id="downloadJsonBtn">Download Report (.json)</button>
           </div>
         </section>
       </div>
@@ -231,6 +374,7 @@
 
     <script>
       const htmlInput = document.getElementById("htmlInput");
+      const pageUrlInput = document.getElementById("pageUrl");
 
       const analyzeBtn = document.getElementById("analyzeBtn");
       const exampleBtn = document.getElementById("exampleBtn");
@@ -238,159 +382,220 @@
 
       const copyBtn = document.getElementById("copyBtn");
       const downloadBtn = document.getElementById("downloadBtn");
+      const downloadJsonBtn = document.getElementById("downloadJsonBtn");
 
       const canonicalUrl = document.getElementById("canonicalUrl");
-      const statusText = document.getElementById("statusText");
-      const recommendation = document.getElementById("recommendation");
-
       const statusCard = document.getElementById("statusCard");
-      function analyzeHTML() {
-        const html = htmlInput.value.trim();
-        if (!html) {
-          statusCard.className = "status warning";
-          statusCard.textContent = "Please paste HTML source.";
+      const scoreCard = document.getElementById("scoreCard");
+      const scoreRing = document.getElementById("scoreRing");
+      const scoreSub = document.getElementById("scoreSub");
+      const issueList = document.getElementById("issueList");
 
-          canonicalUrl.value = "";
-          statusText.value = "No HTML Provided";
-          recommendation.value = "Paste a webpage's HTML source to analyze its canonical tag.";
-          copyBtn.disabled = true;
-          downloadBtn.disabled = true;
-          return;
-        }
-        copyBtn.disabled = false;
-        downloadBtn.disabled = false;
+      // Holds the most recently generated report so Copy/Download stay in sync.
+      let lastReport = null;
+
+      /**
+       * Runs every canonical-tag check against the parsed document and
+       * returns a structured report: a list of issues (each with a
+       * severity, title, and recommendation) plus the resolved canonical
+       * URL and an overall SEO health score.
+       */
+      function buildReport(html, pageUrl) {
+        const issues = [];
+        const addIssue = (severity, title, rec) => issues.push({ severity, title, recommendation: rec });
 
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, "text/html");
 
-        const canonicalTags = doc.querySelectorAll('link[rel="canonical"]');
-        const headCanonical = doc.head.querySelectorAll('link[rel="canonical"]');
+        const canonicalTags = Array.from(doc.querySelectorAll('link[rel="canonical"]'));
+        const headCanonical = Array.from(doc.head.querySelectorAll('link[rel="canonical"]'));
 
+        let resolvedHref = "";
+
+        // --- Placement: outside <head> ---
         if (canonicalTags.length && headCanonical.length === 0) {
-          statusCard.className = "status warning";
-          statusCard.textContent = "Canonical Tag Outside <head>";
-
-          canonicalUrl.value = canonicalTags[0].getAttribute("href") || "";
-
-          statusText.value = "Incorrect Placement";
-
-          recommendation.value = "Move the canonical tag inside the <head> section.";
-
-          return;
+          addIssue("error", "Canonical tag outside <head>", "Move the canonical tag inside the <head> section. Canonical tags outside <head> are ignored by most search engines.");
         }
 
-        // Missing canonical
+        // --- Missing ---
         if (canonicalTags.length === 0) {
-          statusCard.className = "status warning";
-          statusCard.textContent = "No Canonical Tag Found";
-
-          canonicalUrl.value = "";
-          statusText.value = "Missing";
-          recommendation.value = 'Add a <link rel="canonical"> tag inside the <head> section.';
-
-          return;
+          addIssue("error", "No canonical tag found", 'Add a <link rel="canonical" href="..."> tag inside the <head> section so search engines know the preferred URL for this page.');
         }
 
-        // Multiple canonicals
+        // --- Multiple canonical tags ---
         if (canonicalTags.length > 1) {
-          statusCard.className = "status warning";
-          statusCard.textContent = "Multiple Canonical Tags";
-
-          canonicalUrl.value = "";
-          statusText.value = "Conflict";
-          recommendation.value = "Only one canonical tag should exist on a webpage.";
-
-          return;
+          const hrefs = canonicalTags.map((t) => t.getAttribute("href") || "(empty)");
+          addIssue("error", `Multiple canonical tags found (${canonicalTags.length})`, `Only one canonical tag should exist per page. Found: ${hrefs.join(", ")}. Remove all but one.`);
         }
 
-        const href = canonicalTags[0].getAttribute("href");
-        // Empty href
-        if (!href || href.trim() === "") {
-          statusCard.className = "status warning";
-          statusCard.textContent = "Empty Canonical URL";
+        if (canonicalTags.length >= 1) {
+          const href = (canonicalTags[0].getAttribute("href") || "").trim();
+          resolvedHref = href;
 
-          canonicalUrl.value = "";
-          statusText.value = "Invalid";
-          recommendation.value = "The canonical tag exists but its href attribute is empty.";
+          if (!href) {
+            addIssue("error", "Empty canonical URL", "The canonical tag exists but its href attribute is empty. Provide a full, absolute URL.");
+          } else if (!/^https?:\/\//i.test(href)) {
+            addIssue("warning", "Relative canonical URL", `Use an absolute URL (including protocol and domain) instead of a relative canonical URL like "${href}". Relative canonicals are more error-prone and not recommended by Google.`);
+          } else {
+            let parsedHref = null;
+            try {
+              parsedHref = new URL(href);
+            } catch {
+              addIssue("error", "Invalid canonical URL", `"${href}" is not a valid absolute URL. Double-check for typos or malformed syntax.`);
+            }
 
-          return;
+            if (parsedHref) {
+              // --- Canonical chains / self-reference vs a known page URL ---
+              let parsedPage = null;
+              if (pageUrl) {
+                try {
+                  parsedPage = new URL(pageUrl);
+                } catch {
+                  addIssue("warning", "Page URL is not a valid absolute URL", "The optional page URL you provided could not be parsed. Self-reference and protocol checks were skipped.");
+                }
+              }
+
+              if (parsedPage) {
+                const sameUrl = parsedHref.href.replace(/\/$/, "") === parsedPage.href.replace(/\/$/, "");
+                if (!sameUrl) {
+                  addIssue("warning", "Canonical does not self-reference the page URL", `The page at "${parsedPage.href}" declares a canonical pointing to "${parsedHref.href}". This may be intentional (e.g. for duplicate/paginated content) but can also indicate a canonical chain — verify the target page's own canonical also points to itself.`);
+                } else {
+                  addIssue("success", "Canonical self-references the page URL", "The canonical URL matches the page it was found on, which is the expected pattern for a page's primary canonical.");
+                }
+
+                // --- HTTP/HTTPS inconsistency ---
+                if (parsedHref.protocol !== parsedPage.protocol) {
+                  addIssue("warning", "HTTP/HTTPS protocol mismatch", `The page is served over "${parsedPage.protocol}" but the canonical URL uses "${parsedHref.protocol}". Canonical URLs should use the same protocol as the live site (prefer HTTPS).`);
+                }
+              }
+
+              if (parsedHref.protocol !== "https:") {
+                addIssue("warning", "Canonical URL is not HTTPS", "Canonical URLs should point to the HTTPS version of a page when your site supports HTTPS.");
+              }
+
+              if (issues.every((i) => i.severity !== "error")) {
+                addIssue("success", "Canonical tag is well-formed", "Found exactly one canonical tag inside <head>, with a valid absolute URL.");
+              }
+            }
+          }
         }
 
-        let validURL = true;
+        const errorCount = issues.filter((i) => i.severity === "error").length;
+        const warningCount = issues.filter((i) => i.severity === "warning").length;
+        const totalChecks = issues.length || 1;
+        const passedChecks = issues.filter((i) => i.severity === "success").length;
 
-        // Relative URL
-        if (!/^https?:\/\//i.test(href)) {
-          statusCard.className = "status warning";
-          statusCard.textContent = "Relative Canonical URL";
+        // Score: start at 100, subtract per error/warning, floor at 0.
+        let score = 100 - errorCount * 30 - warningCount * 12;
+        score = Math.max(0, Math.min(100, score));
 
-          canonicalUrl.value = href;
-          statusText.value = "Relative URL";
-          recommendation.value = "Use an absolute URL instead of a relative canonical URL.";
-
-          return;
-        }
-
-        try {
-          new URL(href);
-        } catch {
-          validURL = false;
-        }
-
-        if (!validURL) {
-          statusCard.className = "status warning";
-          statusCard.textContent = "Invalid Canonical URL";
-
-          canonicalUrl.value = href;
-          statusText.value = "Invalid URL";
-
-          recommendation.value = "The canonical URL is not a valid absolute URL.";
-
-          return;
-        }
-
-        // Valid
-        statusCard.className = "status success";
-        statusCard.textContent = "Valid Canonical URL";
-
-        canonicalUrl.value = href;
-        statusText.value = "Valid";
-        recommendation.value = `✔ Canonical tag found.
-
-✔ Uses an absolute URL.
-
-✔ Only one canonical tag exists.
-
-✔ Appears correctly implemented for SEO.`;
+        return {
+          canonicalUrl: resolvedHref,
+          issues,
+          score,
+          errorCount,
+          warningCount,
+          totalChecks,
+          passedChecks,
+          overall: errorCount > 0 ? "error" : warningCount > 0 ? "warning" : "success"
+        };
       }
+
+      function scoreTier(score) {
+        if (score >= 80) return "good";
+        if (score >= 50) return "fair";
+        return "poor";
+      }
+
+      function renderReport(report) {
+        canonicalUrl.value = report.canonicalUrl || "";
+
+        if (report.overall === "success") {
+          statusCard.className = "status success";
+          statusCard.textContent = "Valid Canonical Implementation";
+        } else if (report.overall === "warning") {
+          statusCard.className = "status warning";
+          statusCard.textContent = `${report.warningCount} Warning${report.warningCount === 1 ? "" : "s"} Found`;
+        } else {
+          statusCard.className = "status warning";
+          statusCard.textContent = `${report.errorCount} Issue${report.errorCount === 1 ? "" : "s"} Found`;
+        }
+
+        scoreCard.style.display = "flex";
+        scoreRing.textContent = String(report.score);
+        scoreRing.className = "score-ring " + scoreTier(report.score);
+        scoreSub.textContent = `${report.passedChecks} of ${report.totalChecks} checks passed`;
+
+        issueList.innerHTML = report.issues
+          .map(
+            (issue) => `
+          <li class="issue ${issue.severity}">
+            <div class="issue-title">${issue.severity === "success" ? "✔" : issue.severity === "error" ? "✖" : "⚠"} ${escapeHtml(issue.title)}</div>
+            <div class="issue-rec">${escapeHtml(issue.recommendation)}</div>
+          </li>`
+          )
+          .join("");
+      }
+
+      function escapeHtml(str) {
+        return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+      }
+
+      function resetResultUI(message) {
+        statusCard.className = "status neutral";
+        statusCard.textContent = message;
+        canonicalUrl.value = "";
+        scoreCard.style.display = "none";
+        issueList.innerHTML = "";
+        lastReport = null;
+        copyBtn.disabled = true;
+        downloadBtn.disabled = true;
+        downloadJsonBtn.disabled = true;
+      }
+
+      function analyzeHTML() {
+        const html = htmlInput.value.trim();
+        if (!html) {
+          resetResultUI("Please paste HTML source.");
+          return;
+        }
+
+        const pageUrl = pageUrlInput.value.trim();
+        const report = buildReport(html, pageUrl);
+        report.pageUrl = pageUrl || null;
+        lastReport = report;
+
+        renderReport(report);
+        copyBtn.disabled = false;
+        downloadBtn.disabled = false;
+        downloadJsonBtn.disabled = false;
+      }
+
+      function buildTextReport(report) {
+        const lines = ["Canonical URL Checker Report", "", `SEO Health Score: ${report.score}/100 (${report.passedChecks}/${report.totalChecks} checks passed)`, `Canonical URL: ${report.canonicalUrl || "Not Found"}`, report.pageUrl ? `Page URL: ${report.pageUrl}` : null, "", "Issues & Recommendations:"].filter(Boolean);
+
+        report.issues.forEach((issue) => {
+          lines.push(`- [${issue.severity.toUpperCase()}] ${issue.title}`);
+          lines.push(`  ${issue.recommendation}`);
+        });
+
+        return lines.join("\n");
+      }
+
       analyzeBtn.addEventListener("click", analyzeHTML);
       copyBtn.disabled = true;
       downloadBtn.disabled = true;
+      downloadJsonBtn.disabled = true;
+
       resetBtn.addEventListener("click", () => {
         htmlInput.value = "";
-
-        canonicalUrl.value = "";
-
-        statusText.value = "Waiting...";
-
-        recommendation.value = "Paste HTML and click Analyze to check the canonical tag.";
-
-        statusCard.className = "status neutral";
-
-        statusCard.textContent = "Waiting for analysis...";
-        copyBtn.disabled = true;
-        downloadBtn.disabled = true;
+        pageUrlInput.value = "";
+        resetResultUI("Waiting for analysis...");
       });
+
       copyBtn.addEventListener("click", async () => {
-        const report = `Canonical URL Checker Report
-
-Status: ${statusText.value}
-
-Canonical URL:
-${canonicalUrl.value || "Not Found"}
-
-Recommendations:
-${recommendation.value}
-`;
+        if (!lastReport) return;
+        const report = buildTextReport(lastReport);
 
         try {
           await navigator.clipboard.writeText(report);
@@ -406,35 +611,43 @@ ${recommendation.value}
             copyBtn.style.backgroundColor = originalColor || "#1d9bf0";
           }, 2000);
         } catch {
-          alert("Failed to copy report.");
+          // Clipboard API unavailable or blocked (e.g. insecure context) —
+          // fail gracefully without breaking the rest of the tool.
+          alert("Failed to copy report. Your browser may have blocked clipboard access.");
         }
       });
+
       downloadBtn.addEventListener("click", () => {
-        const report = `Canonical URL Checker Report
+        if (!lastReport) return;
+        const report = buildTextReport(lastReport);
 
-Status: ${statusText.value}
-
-Canonical URL:
-${canonicalUrl.value || "Not Found"}
-
-Recommendations:
-${recommendation.value}
-`;
-
-        const blob = new Blob([report], {
-          type: "text/plain"
-        });
-
-        const link = document.createElement("a");
-
-        link.href = URL.createObjectURL(blob);
-
-        link.download = "canonical-url-report.txt";
-
-        link.click();
-
-        URL.revokeObjectURL(link.href);
+        try {
+          const blob = new Blob([report], { type: "text/plain" });
+          const link = document.createElement("a");
+          link.href = URL.createObjectURL(blob);
+          link.download = "canonical-url-report.txt";
+          link.click();
+          URL.revokeObjectURL(link.href);
+        } catch {
+          alert("Failed to download the report in this browser.");
+        }
       });
+
+      downloadJsonBtn.addEventListener("click", () => {
+        if (!lastReport) return;
+
+        try {
+          const blob = new Blob([JSON.stringify(lastReport, null, 2)], { type: "application/json" });
+          const link = document.createElement("a");
+          link.href = URL.createObjectURL(blob);
+          link.download = "canonical-url-report.json";
+          link.click();
+          URL.revokeObjectURL(link.href);
+        } catch {
+          alert("Failed to download the report in this browser.");
+        }
+      });
+
       exampleBtn.addEventListener("click", () => {
         htmlInput.value = `<!DOCTYPE html>
 <html>
@@ -452,6 +665,7 @@ ${recommendation.value}
 
 </body>
 </html>`;
+        pageUrlInput.value = "https://example.com/page";
 
         analyzeHTML();
       });


### PR DESCRIPTION
## What does this PR do?

Closes #560

Expands the Canonical URL Checker with deeper SEO validation, an overall SEO health score, and richer export options.

### Changes
- Replaced the single early-return check with a full checks-accumulator so multiple issues can be reported at once (e.g. a page can have both a relative URL AND a protocol mismatch).
- Added an optional Page URL field to detect canonical chains, self-referencing canonicals, and HTTP/HTTPS protocol inconsistencies between the page and its canonical.
- Added a warning for canonical URLs that are not served over HTTPS.
- Added an SEO Health Score (0-100) with a color-coded ring (good/fair/poor) and a pass/fail breakdown.
- Every issue now shows a severity (error/warning/success) and an actionable recommendation, rendered as a structured issue list instead of a single free-text textarea.
- Added a Download Report (.json) option alongside the existing text report, with copy/download failures now caught and surfaced via an alert instead of throwing.
- Updated `data/tools.json` description and tags to reflect the new SEO score/chain-check capabilities; ran `node scripts/sort-norm.js data/tools.json`.

## Type of Change

- [x] Enhancement to existing tool

## Screenshot

N/A — same two-panel layout with a new score card and structured issue list replacing the old single-line recommendation textarea.

## Checklist

- [x] I have read the Contributing Guide
- [x] My branch follows the naming convention (`feat/description`)
- [x] I have tested my changes locally in at least one modern browser

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file