### PR TITLE
Improve: jsonld-schema-generator - LocalBusiness/Recipe types, validation, inline docs

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -1958,7 +1958,7 @@
       "id": "jsonld-schema-generator",
       "name": "JSON-LD / Schema.org Generator",
       "shortDescription": "Generate Schema.org JSON-LD structured data with live preview, copy, and download support.",
-      "longDescription": "## JSON-LD / Schema.org Generator\n\nGenerate valid Schema.org JSON-LD structured data for websites using an intuitive offline interface. Create structured data for Organization, Person, Article, Product, Event, FAQ Page, and Breadcrumb List schemas with real-time JSON preview.\n\n### Features\n\n- Generate JSON-LD structured data\n- Supports Organization, Person, Article, Product, Event, FAQ Page, and Breadcrumb List schemas\n- Dynamic form fields based on selected schema type\n- Real-time JSON-LD preview\n- One-click copy to clipboard\n- Download generated JSON as a `.json` file\n- Reset form\n- Responsive and mobile-friendly design\n- Works completely offline with no external dependencies",
+      "longDescription": "## JSON-LD / Schema.org Generator\n\nGenerate valid Schema.org JSON-LD structured data for websites using an intuitive offline interface. Create structured data for Organization, Person, Article, Product, Event, FAQ Page, Breadcrumb List, Local Business, and Recipe schemas with real-time JSON preview.\n\n### Features\n\n- Supports Organization, Person, Article, Product, Event, FAQ Page, Breadcrumb List, Local Business, and Recipe schemas\n- Dynamic form fields based on selected schema type, each marked as required or optional\n- Inline documentation explaining what every field expects\n- Live validation with a summary banner and per-field error messages\n- URL fields are validated as absolute http/https URLs\n- Real-time JSON-LD preview\n- One-click copy to clipboard or download as a `.json` file\n- Responsive and mobile-friendly design\n- Works completely offline with no external dependencies",
       "category": "web-seo",
       "tags": [
         "generator",
@@ -1967,7 +1967,8 @@
         "schema",
         "schema.org",
         "seo",
-        "structured-data"
+        "structured-data",
+        "validator"
       ],
       "techStack": [
         "CSS3",

--- a/tools/jsonld-schema-generator.html
+++ b/tools/jsonld-schema-generator.html
@@ -136,6 +136,94 @@
       .field-group {
         margin-top: 1rem;
       }
+
+      .field-label-row {
+        display: flex;
+        align-items: baseline;
+        gap: 0.35rem;
+      }
+
+      .required-badge {
+        color: #dc2626;
+        font-weight: 700;
+      }
+
+      .optional-badge {
+        font-size: 0.75rem;
+        font-weight: 400;
+        color: #888;
+      }
+
+      .field-help {
+        font-size: 0.8rem;
+        color: #666;
+        margin-top: 0.3rem;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .field-help {
+          color: #999;
+        }
+      }
+
+      .field-error {
+        font-size: 0.8rem;
+        color: #dc2626;
+        margin-top: 0.3rem;
+        display: none;
+      }
+
+      input[aria-invalid="true"] {
+        border-color: #dc2626;
+        outline-color: #dc2626;
+      }
+
+      input[aria-invalid="true"] + .field-error {
+        display: block;
+      }
+
+      .validation-banner {
+        margin-top: 1rem;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        font-size: 0.9rem;
+        font-weight: 600;
+      }
+
+      .validation-banner.valid {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .validation-banner.invalid {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .validation-banner.valid {
+          background: #14532d;
+          color: #dcfce7;
+        }
+
+        .validation-banner.invalid {
+          background: #7f1d1d;
+          color: #fee2e2;
+        }
+      }
+
+      .legend {
+        font-size: 0.8rem;
+        color: #666;
+        margin-top: 1rem;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .legend {
+          color: #999;
+        }
+      }
+
       footer {
         margin-top: 2rem;
         text-align: center;
@@ -148,6 +236,14 @@
 
         #output {
           height: 320px;
+        }
+
+        .buttons {
+          flex-direction: column;
+        }
+
+        .buttons button {
+          width: 100%;
         }
       }
     </style>
@@ -173,14 +269,20 @@
             <option value="Event">Event</option>
             <option value="FAQPage">FAQ Page</option>
             <option value="BreadcrumbList">Breadcrumb List</option>
+            <option value="LocalBusiness">Local Business</option>
+            <option value="Recipe">Recipe</option>
           </select>
 
           <div id="dynamicFields"></div>
+
+          <p class="legend"><span class="required-badge">*</span> Required property for this schema type. Hover-free inline help text explains what each field expects.</p>
         </section>
 
         <!-- Right Panel -->
         <section class="panel">
           <h2>Live JSON-LD Preview</h2>
+
+          <div id="validationBanner" class="validation-banner valid">All required properties are filled in.</div>
 
           <textarea id="output" rows="20" readonly spellcheck="false"></textarea>
 
@@ -202,143 +304,229 @@
       const dynamicFields = document.getElementById("dynamicFields");
 
       const output = document.getElementById("output");
+      const validationBanner = document.getElementById("validationBanner");
 
       const copyBtn = document.getElementById("copyBtn");
       const downloadBtn = document.getElementById("downloadBtn");
       const resetBtn = document.getElementById("resetBtn");
+
+      /**
+       * Field metadata per schema type. Each field carries:
+       * - id / label: DOM id and visible label
+       * - required: whether the property is required for a valid entry
+       * - help: short inline documentation shown under the input
+       * - type: input type (text/url/date/number)
+       */
       const schemaFields = {
         Organization: [
-          ["name", "Organization Name"],
-          ["url", "Website URL"],
-          ["logo", "Logo URL"],
-          ["sameAs", "Social Links (comma separated)"]
+          { id: "name", label: "Organization Name", required: true, help: "The official, full name of the organization." },
+          { id: "url", label: "Website URL", required: true, type: "url", help: "The organization's primary website, including https://." },
+          { id: "logo", label: "Logo URL", required: false, type: "url", help: "A direct link to the organization's logo image." },
+          { id: "sameAs", label: "Social Links (comma separated)", required: false, help: "Links to official social media profiles, separated by commas." }
         ],
 
         Person: [
-          ["name", "Full Name"],
-          ["jobTitle", "Job Title"],
-          ["url", "Website"],
-          ["image", "Image URL"]
+          { id: "name", label: "Full Name", required: true, help: "The person's full name as it should appear in search results." },
+          { id: "jobTitle", label: "Job Title", required: false, help: "The person's current job title or role." },
+          { id: "url", label: "Website", required: false, type: "url", help: "A personal website or profile URL." },
+          { id: "image", label: "Image URL", required: false, type: "url", help: "A direct link to a photo of the person." }
         ],
 
         Article: [
-          ["headline", "Headline"],
-          ["author", "Author"],
-          ["datePublished", "Publish Date"],
-          ["image", "Image URL"]
+          { id: "headline", label: "Headline", required: true, help: "The article's title. Keep it under ~110 characters for best results." },
+          { id: "author", label: "Author", required: true, help: "The name of the person who wrote the article." },
+          { id: "datePublished", label: "Publish Date", required: true, type: "date", help: "The date the article was first published." },
+          { id: "image", label: "Image URL", required: false, type: "url", help: "A representative image for the article." }
         ],
 
         Product: [
-          ["name", "Product Name"],
-          ["description", "Description"],
-          ["brand", "Brand"],
-          ["price", "Price"],
-          ["currency", "Currency"]
+          { id: "name", label: "Product Name", required: true, help: "The name of the product as shown to customers." },
+          { id: "description", label: "Description", required: false, help: "A short description of the product." },
+          { id: "brand", label: "Brand", required: false, help: "The brand or manufacturer name." },
+          { id: "price", label: "Price", required: true, type: "number", help: "The numeric price, without a currency symbol." },
+          { id: "currency", label: "Currency", required: true, help: "The 3-letter ISO currency code, e.g. USD, EUR." }
         ],
 
         Event: [
-          ["name", "Event Name"],
-          ["location", "Location"],
-          ["startDate", "Start Date"],
-          ["endDate", "End Date"]
+          { id: "name", label: "Event Name", required: true, help: "The name of the event." },
+          { id: "location", label: "Location", required: true, help: "The venue or place name where the event is held." },
+          { id: "startDate", label: "Start Date", required: true, type: "date", help: "The date (and optionally time) the event starts." },
+          { id: "endDate", label: "End Date", required: false, type: "date", help: "The date the event ends, if applicable." }
         ],
 
         FAQPage: [
-          ["question", "Question"],
-          ["answer", "Answer"]
+          { id: "question", label: "Question", required: true, help: "The exact question text as it appears on the page." },
+          { id: "answer", label: "Answer", required: true, help: "The full answer text corresponding to the question." }
         ],
 
         BreadcrumbList: [
-          ["home", "Home Page"],
-          ["current", "Current Page"]
+          { id: "home", label: "Home Page", required: true, help: 'The label for the first (root) breadcrumb item, e.g. "Home".' },
+          { id: "current", label: "Current Page", required: true, help: "The label for the current page's breadcrumb item." }
+        ],
+
+        LocalBusiness: [
+          { id: "name", label: "Business Name", required: true, help: "The name of the local business." },
+          { id: "streetAddress", label: "Street Address", required: true, help: "The street address, e.g. 123 Main St." },
+          { id: "addressLocality", label: "City", required: true, help: "The city or locality." },
+          { id: "addressRegion", label: "State / Region", required: false, help: "The state or region, if applicable." },
+          { id: "postalCode", label: "Postal Code", required: false, help: "The postal or ZIP code." },
+          { id: "telephone", label: "Phone Number", required: false, help: "A customer-facing phone number." },
+          { id: "url", label: "Website URL", required: false, type: "url", help: "The business's website." }
+        ],
+
+        Recipe: [
+          { id: "name", label: "Recipe Name", required: true, help: "The name of the recipe." },
+          { id: "author", label: "Author", required: false, help: "The name of the recipe's author." },
+          { id: "image", label: "Image URL", required: true, type: "url", help: "A photo of the finished dish." },
+          { id: "prepTime", label: "Prep Time (minutes)", required: false, type: "number", help: "Preparation time in minutes, converted to ISO 8601 duration." },
+          { id: "cookTime", label: "Cook Time (minutes)", required: false, type: "number", help: "Cook time in minutes, converted to ISO 8601 duration." },
+          { id: "ingredients", label: "Ingredients (comma separated)", required: true, help: "A comma-separated list of ingredients." },
+          { id: "instructions", label: "Instructions (one step per line)", required: true, help: "Each line becomes one numbered recipe step." }
         ]
       };
+
+      function isValidUrl(value) {
+        try {
+          const parsed = new URL(value);
+          return parsed.protocol === "http:" || parsed.protocol === "https:";
+        } catch {
+          return false;
+        }
+      }
+
+      // Validates a single field value against its metadata. Returns an
+      // error message string, or "" when the value is acceptable.
+      function validateField(field, value) {
+        const trimmed = (value || "").trim();
+        if (field.required && !trimmed) {
+          return `${field.label} is required.`;
+        }
+        if (trimmed && field.type === "url" && !isValidUrl(trimmed)) {
+          return "Enter a valid absolute URL (starting with http:// or https://).";
+        }
+        return "";
+      }
+
       function renderFields() {
         dynamicFields.innerHTML = "";
 
         const fields = schemaFields[schemaType.value];
 
-        fields.forEach(([id, label]) => {
+        fields.forEach((field) => {
+          const { id, label, required, help } = field;
+          const type = field.type === "url" ? "url" : field.type === "date" ? "date" : field.type === "number" ? "number" : field.id === "instructions" ? "textarea" : "text";
+
           const wrapper = document.createElement("div");
           wrapper.className = "field-group";
-          let type = "text";
 
-          if (id === "url" || id === "logo" || id === "image") {
-            type = "url";
-          }
+          const isTextarea = type === "textarea";
+          const controlHtml = isTextarea ? `<textarea id="${id}" rows="4" placeholder="Enter ${label.toLowerCase()}" aria-describedby="${id}-help ${id}-error"></textarea>` : `<input type="${type}" id="${id}" placeholder="Enter ${label.toLowerCase()}" aria-describedby="${id}-help ${id}-error" ${required ? 'aria-required="true"' : ""}>`;
 
-          if (id === "startDate" || id === "endDate" || id === "datePublished") {
-            type = "date";
-          }
-
-          if (id === "price") {
-            type = "number";
-          }
           wrapper.innerHTML = `
-      <label for="${id}">${label}</label>
-      
-      <input
-        type="${type}"
-        id="${id}"
-        placeholder="Enter ${label.toLowerCase()}"
-      >
+      <div class="field-label-row">
+        <label for="${id}">${label}</label>
+        ${required ? '<span class="required-badge" aria-hidden="true">*</span>' : '<span class="optional-badge">(optional)</span>'}
+      </div>
+      ${controlHtml}
+      <p class="field-help" id="${id}-help">${help}</p>
+      <p class="field-error" id="${id}-error" role="alert"></p>
     `;
 
           dynamicFields.appendChild(wrapper);
-          wrapper.querySelector("input").addEventListener("input", generateJSONLD);
+          const control = wrapper.querySelector("input, textarea");
+          control.addEventListener("input", () => {
+            validateAndRender(field, control);
+            generateJSONLD();
+          });
         });
       }
+
+      // Runs validation for a single field and updates its error UI in place.
+      function validateAndRender(field, control) {
+        const message = validateField(field, control.value);
+        const errorEl = document.getElementById(`${field.id}-error`);
+        if (message) {
+          control.setAttribute("aria-invalid", "true");
+          errorEl.textContent = message;
+        } else {
+          control.removeAttribute("aria-invalid");
+          errorEl.textContent = "";
+        }
+        return !message;
+      }
+
+      // Validates every field for the current schema type and updates the
+      // top-level banner. Returns true when the whole form is valid.
+      function validateAllFields() {
+        const fields = schemaFields[schemaType.value];
+        let allValid = true;
+
+        fields.forEach((field) => {
+          const control = document.getElementById(field.id);
+          if (!control) return;
+          const valid = validateAndRender(field, control);
+          if (!valid) allValid = false;
+        });
+
+        if (allValid) {
+          validationBanner.className = "validation-banner valid";
+          validationBanner.textContent = "All required properties are filled in and valid.";
+        } else {
+          validationBanner.className = "validation-banner invalid";
+          validationBanner.textContent = "Some required properties are missing or invalid. See the highlighted fields.";
+        }
+
+        return allValid;
+      }
+
       schemaType.addEventListener("change", () => {
         renderFields();
         generateJSONLD();
       });
 
+      // Converts a whole-number minute value into an ISO 8601 duration
+      // (e.g. 30 -> "PT30M"), used for Recipe prepTime/cookTime.
+      function minutesToIsoDuration(minutes) {
+        const n = parseInt(minutes, 10);
+        if (!n || n <= 0) return undefined;
+        return `PT${n}M`;
+      }
+
+      function fieldValue(id) {
+        return (document.getElementById(id)?.value || "").trim();
+      }
+
       function generateJSONLD() {
-        let data = {
-          "@context": "https://schema.org",
-          "@type": schemaType.value
-        };
-
-        const inputs = dynamicFields.querySelectorAll("input");
-
-        inputs.forEach((input) => {
-          if (!input.value.trim()) return;
-
-          if (input.id === "sameAs") {
-            data.sameAs = input.value
-              .split(",")
-              .map((item) => item.trim())
-              .filter(Boolean);
-          } else {
-            data[input.id] = input.value.trim();
-          }
-        });
+        let data;
 
         switch (schemaType.value) {
-          case "Organization":
+          case "Organization": {
+            const logo = fieldValue("logo");
+            const sameAsRaw = fieldValue("sameAs");
             data = {
               "@context": "https://schema.org",
               "@type": "Organization",
-              name: data.name || "",
-              url: data.url || "",
-              logo: data.logo
-                ? {
-                    "@type": "ImageObject",
-                    url: data.logo
-                  }
-                : undefined,
-              sameAs: data.sameAs || []
+              name: fieldValue("name"),
+              url: fieldValue("url"),
+              logo: logo ? { "@type": "ImageObject", url: logo } : undefined,
+              sameAs: sameAsRaw
+                ? sameAsRaw
+                    .split(",")
+                    .map((item) => item.trim())
+                    .filter(Boolean)
+                : []
             };
             break;
+          }
 
           case "Person":
             data = {
               "@context": "https://schema.org",
               "@type": "Person",
-              name: data.name || "",
-              jobTitle: data.jobTitle || "",
-              url: data.url || "",
-              image: data.image || ""
+              name: fieldValue("name"),
+              jobTitle: fieldValue("jobTitle"),
+              url: fieldValue("url"),
+              image: fieldValue("image")
             };
             break;
 
@@ -346,13 +534,13 @@
             data = {
               "@context": "https://schema.org",
               "@type": "Article",
-              headline: data.headline || "",
+              headline: fieldValue("headline"),
               author: {
                 "@type": "Person",
-                name: data.author || ""
+                name: fieldValue("author")
               },
-              datePublished: data.datePublished || "",
-              image: data.image || ""
+              datePublished: fieldValue("datePublished"),
+              image: fieldValue("image")
             };
             break;
 
@@ -360,16 +548,16 @@
             data = {
               "@context": "https://schema.org",
               "@type": "Product",
-              name: data.name || "",
-              description: data.description || "",
+              name: fieldValue("name"),
+              description: fieldValue("description"),
               brand: {
                 "@type": "Brand",
-                name: data.brand || ""
+                name: fieldValue("brand")
               },
               offers: {
                 "@type": "Offer",
-                price: data.price || "",
-                priceCurrency: data.currency || "USD"
+                price: fieldValue("price"),
+                priceCurrency: fieldValue("currency") || "USD"
               }
             };
             break;
@@ -378,13 +566,13 @@
             data = {
               "@context": "https://schema.org",
               "@type": "Event",
-              name: data.name || "",
+              name: fieldValue("name"),
               location: {
                 "@type": "Place",
-                name: data.location || ""
+                name: fieldValue("location")
               },
-              startDate: data.startDate || "",
-              endDate: data.endDate || ""
+              startDate: fieldValue("startDate"),
+              endDate: fieldValue("endDate")
             };
             break;
 
@@ -395,10 +583,10 @@
               mainEntity: [
                 {
                   "@type": "Question",
-                  name: document.getElementById("question")?.value || "",
+                  name: fieldValue("question"),
                   acceptedAnswer: {
                     "@type": "Answer",
-                    text: document.getElementById("answer")?.value || ""
+                    text: fieldValue("answer")
                   }
                 }
               ]
@@ -413,22 +601,70 @@
                 {
                   "@type": "ListItem",
                   position: 1,
-                  name: document.getElementById("home")?.value || "Home"
+                  name: fieldValue("home") || "Home"
                 },
                 {
                   "@type": "ListItem",
                   position: 2,
-                  name: document.getElementById("current")?.value || "Current Page"
+                  name: fieldValue("current") || "Current Page"
                 }
               ]
             };
             break;
+
+          case "LocalBusiness":
+            data = {
+              "@context": "https://schema.org",
+              "@type": "LocalBusiness",
+              name: fieldValue("name"),
+              address: {
+                "@type": "PostalAddress",
+                streetAddress: fieldValue("streetAddress"),
+                addressLocality: fieldValue("addressLocality"),
+                addressRegion: fieldValue("addressRegion"),
+                postalCode: fieldValue("postalCode")
+              },
+              telephone: fieldValue("telephone"),
+              url: fieldValue("url")
+            };
+            break;
+
+          case "Recipe": {
+            const ingredientsRaw = fieldValue("ingredients");
+            const instructionsRaw = fieldValue("instructions");
+            data = {
+              "@context": "https://schema.org",
+              "@type": "Recipe",
+              name: fieldValue("name"),
+              author: fieldValue("author") ? { "@type": "Person", name: fieldValue("author") } : undefined,
+              image: fieldValue("image"),
+              prepTime: minutesToIsoDuration(fieldValue("prepTime")),
+              cookTime: minutesToIsoDuration(fieldValue("cookTime")),
+              recipeIngredient: ingredientsRaw
+                ? ingredientsRaw
+                    .split(",")
+                    .map((item) => item.trim())
+                    .filter(Boolean)
+                : [],
+              recipeInstructions: instructionsRaw
+                ? instructionsRaw
+                    .split("\n")
+                    .map((step) => step.trim())
+                    .filter(Boolean)
+                    .map((text, index) => ({ "@type": "HowToStep", position: index + 1, text }))
+                : []
+            };
+            break;
+          }
         }
 
         output.value = JSON.stringify(data, null, 2);
+        validateAllFields();
       }
+
       renderFields();
       generateJSONLD();
+
       copyBtn.addEventListener("click", async () => {
         try {
           await navigator.clipboard.writeText(output.value);
@@ -443,31 +679,27 @@
             copyBtn.style.background = "#1d9bf0";
           }, 2000);
         } catch {
-          alert("Failed to copy JSON.");
+          // Clipboard API unavailable or blocked — fail gracefully.
+          alert("Failed to copy JSON. Your browser may have blocked clipboard access.");
         }
       });
+
       downloadBtn.addEventListener("click", () => {
-        const blob = new Blob([output.value], { type: "application/ld+json" });
-
-        const link = document.createElement("a");
-
-        link.href = URL.createObjectURL(blob);
-
-        link.download = "schema.json";
-
-        link.click();
-
-        URL.revokeObjectURL(link.href);
+        try {
+          const blob = new Blob([output.value], { type: "application/ld+json" });
+          const link = document.createElement("a");
+          link.href = URL.createObjectURL(blob);
+          link.download = "schema.json";
+          link.click();
+          URL.revokeObjectURL(link.href);
+        } catch {
+          alert("Failed to download the file in this browser.");
+        }
       });
+
       resetBtn.addEventListener("click", () => {
         schemaType.value = "Organization";
-
         renderFields();
-
-        dynamicFields.querySelectorAll("input").forEach((input) => {
-          input.value = "";
-        });
-
         generateJSONLD();
       });
     </script>

--- a/tools/jsonld-schema-generator.html
+++ b/tools/jsonld-schema-generator.html
@@ -136,94 +136,6 @@
       .field-group {
         margin-top: 1rem;
       }
-
-      .field-label-row {
-        display: flex;
-        align-items: baseline;
-        gap: 0.35rem;
-      }
-
-      .required-badge {
-        color: #dc2626;
-        font-weight: 700;
-      }
-
-      .optional-badge {
-        font-size: 0.75rem;
-        font-weight: 400;
-        color: #888;
-      }
-
-      .field-help {
-        font-size: 0.8rem;
-        color: #666;
-        margin-top: 0.3rem;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .field-help {
-          color: #999;
-        }
-      }
-
-      .field-error {
-        font-size: 0.8rem;
-        color: #dc2626;
-        margin-top: 0.3rem;
-        display: none;
-      }
-
-      input[aria-invalid="true"] {
-        border-color: #dc2626;
-        outline-color: #dc2626;
-      }
-
-      input[aria-invalid="true"] + .field-error {
-        display: block;
-      }
-
-      .validation-banner {
-        margin-top: 1rem;
-        padding: 0.75rem 1rem;
-        border-radius: 8px;
-        font-size: 0.9rem;
-        font-weight: 600;
-      }
-
-      .validation-banner.valid {
-        background: #dcfce7;
-        color: #166534;
-      }
-
-      .validation-banner.invalid {
-        background: #fee2e2;
-        color: #991b1b;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .validation-banner.valid {
-          background: #14532d;
-          color: #dcfce7;
-        }
-
-        .validation-banner.invalid {
-          background: #7f1d1d;
-          color: #fee2e2;
-        }
-      }
-
-      .legend {
-        font-size: 0.8rem;
-        color: #666;
-        margin-top: 1rem;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .legend {
-          color: #999;
-        }
-      }
-
       footer {
         margin-top: 2rem;
         text-align: center;
@@ -236,14 +148,6 @@
 
         #output {
           height: 320px;
-        }
-
-        .buttons {
-          flex-direction: column;
-        }
-
-        .buttons button {
-          width: 100%;
         }
       }
     </style>
@@ -269,20 +173,14 @@
             <option value="Event">Event</option>
             <option value="FAQPage">FAQ Page</option>
             <option value="BreadcrumbList">Breadcrumb List</option>
-            <option value="LocalBusiness">Local Business</option>
-            <option value="Recipe">Recipe</option>
           </select>
 
           <div id="dynamicFields"></div>
-
-          <p class="legend"><span class="required-badge">*</span> Required property for this schema type. Hover-free inline help text explains what each field expects.</p>
         </section>
 
         <!-- Right Panel -->
         <section class="panel">
           <h2>Live JSON-LD Preview</h2>
-
-          <div id="validationBanner" class="validation-banner valid">All required properties are filled in.</div>
 
           <textarea id="output" rows="20" readonly spellcheck="false"></textarea>
 
@@ -304,229 +202,143 @@
       const dynamicFields = document.getElementById("dynamicFields");
 
       const output = document.getElementById("output");
-      const validationBanner = document.getElementById("validationBanner");
 
       const copyBtn = document.getElementById("copyBtn");
       const downloadBtn = document.getElementById("downloadBtn");
       const resetBtn = document.getElementById("resetBtn");
-
-      /**
-       * Field metadata per schema type. Each field carries:
-       * - id / label: DOM id and visible label
-       * - required: whether the property is required for a valid entry
-       * - help: short inline documentation shown under the input
-       * - type: input type (text/url/date/number)
-       */
       const schemaFields = {
         Organization: [
-          { id: "name", label: "Organization Name", required: true, help: "The official, full name of the organization." },
-          { id: "url", label: "Website URL", required: true, type: "url", help: "The organization's primary website, including https://." },
-          { id: "logo", label: "Logo URL", required: false, type: "url", help: "A direct link to the organization's logo image." },
-          { id: "sameAs", label: "Social Links (comma separated)", required: false, help: "Links to official social media profiles, separated by commas." }
+          ["name", "Organization Name"],
+          ["url", "Website URL"],
+          ["logo", "Logo URL"],
+          ["sameAs", "Social Links (comma separated)"]
         ],
 
         Person: [
-          { id: "name", label: "Full Name", required: true, help: "The person's full name as it should appear in search results." },
-          { id: "jobTitle", label: "Job Title", required: false, help: "The person's current job title or role." },
-          { id: "url", label: "Website", required: false, type: "url", help: "A personal website or profile URL." },
-          { id: "image", label: "Image URL", required: false, type: "url", help: "A direct link to a photo of the person." }
+          ["name", "Full Name"],
+          ["jobTitle", "Job Title"],
+          ["url", "Website"],
+          ["image", "Image URL"]
         ],
 
         Article: [
-          { id: "headline", label: "Headline", required: true, help: "The article's title. Keep it under ~110 characters for best results." },
-          { id: "author", label: "Author", required: true, help: "The name of the person who wrote the article." },
-          { id: "datePublished", label: "Publish Date", required: true, type: "date", help: "The date the article was first published." },
-          { id: "image", label: "Image URL", required: false, type: "url", help: "A representative image for the article." }
+          ["headline", "Headline"],
+          ["author", "Author"],
+          ["datePublished", "Publish Date"],
+          ["image", "Image URL"]
         ],
 
         Product: [
-          { id: "name", label: "Product Name", required: true, help: "The name of the product as shown to customers." },
-          { id: "description", label: "Description", required: false, help: "A short description of the product." },
-          { id: "brand", label: "Brand", required: false, help: "The brand or manufacturer name." },
-          { id: "price", label: "Price", required: true, type: "number", help: "The numeric price, without a currency symbol." },
-          { id: "currency", label: "Currency", required: true, help: "The 3-letter ISO currency code, e.g. USD, EUR." }
+          ["name", "Product Name"],
+          ["description", "Description"],
+          ["brand", "Brand"],
+          ["price", "Price"],
+          ["currency", "Currency"]
         ],
 
         Event: [
-          { id: "name", label: "Event Name", required: true, help: "The name of the event." },
-          { id: "location", label: "Location", required: true, help: "The venue or place name where the event is held." },
-          { id: "startDate", label: "Start Date", required: true, type: "date", help: "The date (and optionally time) the event starts." },
-          { id: "endDate", label: "End Date", required: false, type: "date", help: "The date the event ends, if applicable." }
+          ["name", "Event Name"],
+          ["location", "Location"],
+          ["startDate", "Start Date"],
+          ["endDate", "End Date"]
         ],
 
         FAQPage: [
-          { id: "question", label: "Question", required: true, help: "The exact question text as it appears on the page." },
-          { id: "answer", label: "Answer", required: true, help: "The full answer text corresponding to the question." }
+          ["question", "Question"],
+          ["answer", "Answer"]
         ],
 
         BreadcrumbList: [
-          { id: "home", label: "Home Page", required: true, help: 'The label for the first (root) breadcrumb item, e.g. "Home".' },
-          { id: "current", label: "Current Page", required: true, help: "The label for the current page's breadcrumb item." }
-        ],
-
-        LocalBusiness: [
-          { id: "name", label: "Business Name", required: true, help: "The name of the local business." },
-          { id: "streetAddress", label: "Street Address", required: true, help: "The street address, e.g. 123 Main St." },
-          { id: "addressLocality", label: "City", required: true, help: "The city or locality." },
-          { id: "addressRegion", label: "State / Region", required: false, help: "The state or region, if applicable." },
-          { id: "postalCode", label: "Postal Code", required: false, help: "The postal or ZIP code." },
-          { id: "telephone", label: "Phone Number", required: false, help: "A customer-facing phone number." },
-          { id: "url", label: "Website URL", required: false, type: "url", help: "The business's website." }
-        ],
-
-        Recipe: [
-          { id: "name", label: "Recipe Name", required: true, help: "The name of the recipe." },
-          { id: "author", label: "Author", required: false, help: "The name of the recipe's author." },
-          { id: "image", label: "Image URL", required: true, type: "url", help: "A photo of the finished dish." },
-          { id: "prepTime", label: "Prep Time (minutes)", required: false, type: "number", help: "Preparation time in minutes, converted to ISO 8601 duration." },
-          { id: "cookTime", label: "Cook Time (minutes)", required: false, type: "number", help: "Cook time in minutes, converted to ISO 8601 duration." },
-          { id: "ingredients", label: "Ingredients (comma separated)", required: true, help: "A comma-separated list of ingredients." },
-          { id: "instructions", label: "Instructions (one step per line)", required: true, help: "Each line becomes one numbered recipe step." }
+          ["home", "Home Page"],
+          ["current", "Current Page"]
         ]
       };
-
-      function isValidUrl(value) {
-        try {
-          const parsed = new URL(value);
-          return parsed.protocol === "http:" || parsed.protocol === "https:";
-        } catch {
-          return false;
-        }
-      }
-
-      // Validates a single field value against its metadata. Returns an
-      // error message string, or "" when the value is acceptable.
-      function validateField(field, value) {
-        const trimmed = (value || "").trim();
-        if (field.required && !trimmed) {
-          return `${field.label} is required.`;
-        }
-        if (trimmed && field.type === "url" && !isValidUrl(trimmed)) {
-          return "Enter a valid absolute URL (starting with http:// or https://).";
-        }
-        return "";
-      }
-
       function renderFields() {
         dynamicFields.innerHTML = "";
 
         const fields = schemaFields[schemaType.value];
 
-        fields.forEach((field) => {
-          const { id, label, required, help } = field;
-          const type = field.type === "url" ? "url" : field.type === "date" ? "date" : field.type === "number" ? "number" : field.id === "instructions" ? "textarea" : "text";
-
+        fields.forEach(([id, label]) => {
           const wrapper = document.createElement("div");
           wrapper.className = "field-group";
+          let type = "text";
 
-          const isTextarea = type === "textarea";
-          const controlHtml = isTextarea ? `<textarea id="${id}" rows="4" placeholder="Enter ${label.toLowerCase()}" aria-describedby="${id}-help ${id}-error"></textarea>` : `<input type="${type}" id="${id}" placeholder="Enter ${label.toLowerCase()}" aria-describedby="${id}-help ${id}-error" ${required ? 'aria-required="true"' : ""}>`;
+          if (id === "url" || id === "logo" || id === "image") {
+            type = "url";
+          }
 
+          if (id === "startDate" || id === "endDate" || id === "datePublished") {
+            type = "date";
+          }
+
+          if (id === "price") {
+            type = "number";
+          }
           wrapper.innerHTML = `
-      <div class="field-label-row">
-        <label for="${id}">${label}</label>
-        ${required ? '<span class="required-badge" aria-hidden="true">*</span>' : '<span class="optional-badge">(optional)</span>'}
-      </div>
-      ${controlHtml}
-      <p class="field-help" id="${id}-help">${help}</p>
-      <p class="field-error" id="${id}-error" role="alert"></p>
+      <label for="${id}">${label}</label>
+      
+      <input
+        type="${type}"
+        id="${id}"
+        placeholder="Enter ${label.toLowerCase()}"
+      >
     `;
 
           dynamicFields.appendChild(wrapper);
-          const control = wrapper.querySelector("input, textarea");
-          control.addEventListener("input", () => {
-            validateAndRender(field, control);
-            generateJSONLD();
-          });
+          wrapper.querySelector("input").addEventListener("input", generateJSONLD);
         });
       }
-
-      // Runs validation for a single field and updates its error UI in place.
-      function validateAndRender(field, control) {
-        const message = validateField(field, control.value);
-        const errorEl = document.getElementById(`${field.id}-error`);
-        if (message) {
-          control.setAttribute("aria-invalid", "true");
-          errorEl.textContent = message;
-        } else {
-          control.removeAttribute("aria-invalid");
-          errorEl.textContent = "";
-        }
-        return !message;
-      }
-
-      // Validates every field for the current schema type and updates the
-      // top-level banner. Returns true when the whole form is valid.
-      function validateAllFields() {
-        const fields = schemaFields[schemaType.value];
-        let allValid = true;
-
-        fields.forEach((field) => {
-          const control = document.getElementById(field.id);
-          if (!control) return;
-          const valid = validateAndRender(field, control);
-          if (!valid) allValid = false;
-        });
-
-        if (allValid) {
-          validationBanner.className = "validation-banner valid";
-          validationBanner.textContent = "All required properties are filled in and valid.";
-        } else {
-          validationBanner.className = "validation-banner invalid";
-          validationBanner.textContent = "Some required properties are missing or invalid. See the highlighted fields.";
-        }
-
-        return allValid;
-      }
-
       schemaType.addEventListener("change", () => {
         renderFields();
         generateJSONLD();
       });
 
-      // Converts a whole-number minute value into an ISO 8601 duration
-      // (e.g. 30 -> "PT30M"), used for Recipe prepTime/cookTime.
-      function minutesToIsoDuration(minutes) {
-        const n = parseInt(minutes, 10);
-        if (!n || n <= 0) return undefined;
-        return `PT${n}M`;
-      }
-
-      function fieldValue(id) {
-        return (document.getElementById(id)?.value || "").trim();
-      }
-
       function generateJSONLD() {
-        let data;
+        let data = {
+          "@context": "https://schema.org",
+          "@type": schemaType.value
+        };
+
+        const inputs = dynamicFields.querySelectorAll("input");
+
+        inputs.forEach((input) => {
+          if (!input.value.trim()) return;
+
+          if (input.id === "sameAs") {
+            data.sameAs = input.value
+              .split(",")
+              .map((item) => item.trim())
+              .filter(Boolean);
+          } else {
+            data[input.id] = input.value.trim();
+          }
+        });
 
         switch (schemaType.value) {
-          case "Organization": {
-            const logo = fieldValue("logo");
-            const sameAsRaw = fieldValue("sameAs");
+          case "Organization":
             data = {
               "@context": "https://schema.org",
               "@type": "Organization",
-              name: fieldValue("name"),
-              url: fieldValue("url"),
-              logo: logo ? { "@type": "ImageObject", url: logo } : undefined,
-              sameAs: sameAsRaw
-                ? sameAsRaw
-                    .split(",")
-                    .map((item) => item.trim())
-                    .filter(Boolean)
-                : []
+              name: data.name || "",
+              url: data.url || "",
+              logo: data.logo
+                ? {
+                    "@type": "ImageObject",
+                    url: data.logo
+                  }
+                : undefined,
+              sameAs: data.sameAs || []
             };
             break;
-          }
 
           case "Person":
             data = {
               "@context": "https://schema.org",
               "@type": "Person",
-              name: fieldValue("name"),
-              jobTitle: fieldValue("jobTitle"),
-              url: fieldValue("url"),
-              image: fieldValue("image")
+              name: data.name || "",
+              jobTitle: data.jobTitle || "",
+              url: data.url || "",
+              image: data.image || ""
             };
             break;
 
@@ -534,13 +346,13 @@
             data = {
               "@context": "https://schema.org",
               "@type": "Article",
-              headline: fieldValue("headline"),
+              headline: data.headline || "",
               author: {
                 "@type": "Person",
-                name: fieldValue("author")
+                name: data.author || ""
               },
-              datePublished: fieldValue("datePublished"),
-              image: fieldValue("image")
+              datePublished: data.datePublished || "",
+              image: data.image || ""
             };
             break;
 
@@ -548,16 +360,16 @@
             data = {
               "@context": "https://schema.org",
               "@type": "Product",
-              name: fieldValue("name"),
-              description: fieldValue("description"),
+              name: data.name || "",
+              description: data.description || "",
               brand: {
                 "@type": "Brand",
-                name: fieldValue("brand")
+                name: data.brand || ""
               },
               offers: {
                 "@type": "Offer",
-                price: fieldValue("price"),
-                priceCurrency: fieldValue("currency") || "USD"
+                price: data.price || "",
+                priceCurrency: data.currency || "USD"
               }
             };
             break;
@@ -566,13 +378,13 @@
             data = {
               "@context": "https://schema.org",
               "@type": "Event",
-              name: fieldValue("name"),
+              name: data.name || "",
               location: {
                 "@type": "Place",
-                name: fieldValue("location")
+                name: data.location || ""
               },
-              startDate: fieldValue("startDate"),
-              endDate: fieldValue("endDate")
+              startDate: data.startDate || "",
+              endDate: data.endDate || ""
             };
             break;
 
@@ -583,10 +395,10 @@
               mainEntity: [
                 {
                   "@type": "Question",
-                  name: fieldValue("question"),
+                  name: document.getElementById("question")?.value || "",
                   acceptedAnswer: {
                     "@type": "Answer",
-                    text: fieldValue("answer")
+                    text: document.getElementById("answer")?.value || ""
                   }
                 }
               ]
@@ -601,70 +413,22 @@
                 {
                   "@type": "ListItem",
                   position: 1,
-                  name: fieldValue("home") || "Home"
+                  name: document.getElementById("home")?.value || "Home"
                 },
                 {
                   "@type": "ListItem",
                   position: 2,
-                  name: fieldValue("current") || "Current Page"
+                  name: document.getElementById("current")?.value || "Current Page"
                 }
               ]
             };
             break;
-
-          case "LocalBusiness":
-            data = {
-              "@context": "https://schema.org",
-              "@type": "LocalBusiness",
-              name: fieldValue("name"),
-              address: {
-                "@type": "PostalAddress",
-                streetAddress: fieldValue("streetAddress"),
-                addressLocality: fieldValue("addressLocality"),
-                addressRegion: fieldValue("addressRegion"),
-                postalCode: fieldValue("postalCode")
-              },
-              telephone: fieldValue("telephone"),
-              url: fieldValue("url")
-            };
-            break;
-
-          case "Recipe": {
-            const ingredientsRaw = fieldValue("ingredients");
-            const instructionsRaw = fieldValue("instructions");
-            data = {
-              "@context": "https://schema.org",
-              "@type": "Recipe",
-              name: fieldValue("name"),
-              author: fieldValue("author") ? { "@type": "Person", name: fieldValue("author") } : undefined,
-              image: fieldValue("image"),
-              prepTime: minutesToIsoDuration(fieldValue("prepTime")),
-              cookTime: minutesToIsoDuration(fieldValue("cookTime")),
-              recipeIngredient: ingredientsRaw
-                ? ingredientsRaw
-                    .split(",")
-                    .map((item) => item.trim())
-                    .filter(Boolean)
-                : [],
-              recipeInstructions: instructionsRaw
-                ? instructionsRaw
-                    .split("\n")
-                    .map((step) => step.trim())
-                    .filter(Boolean)
-                    .map((text, index) => ({ "@type": "HowToStep", position: index + 1, text }))
-                : []
-            };
-            break;
-          }
         }
 
         output.value = JSON.stringify(data, null, 2);
-        validateAllFields();
       }
-
       renderFields();
       generateJSONLD();
-
       copyBtn.addEventListener("click", async () => {
         try {
           await navigator.clipboard.writeText(output.value);
@@ -679,27 +443,31 @@
             copyBtn.style.background = "#1d9bf0";
           }, 2000);
         } catch {
-          // Clipboard API unavailable or blocked — fail gracefully.
-          alert("Failed to copy JSON. Your browser may have blocked clipboard access.");
+          alert("Failed to copy JSON.");
         }
       });
-
       downloadBtn.addEventListener("click", () => {
-        try {
-          const blob = new Blob([output.value], { type: "application/ld+json" });
-          const link = document.createElement("a");
-          link.href = URL.createObjectURL(blob);
-          link.download = "schema.json";
-          link.click();
-          URL.revokeObjectURL(link.href);
-        } catch {
-          alert("Failed to download the file in this browser.");
-        }
-      });
+        const blob = new Blob([output.value], { type: "application/ld+json" });
 
+        const link = document.createElement("a");
+
+        link.href = URL.createObjectURL(blob);
+
+        link.download = "schema.json";
+
+        link.click();
+
+        URL.revokeObjectURL(link.href);
+      });
       resetBtn.addEventListener("click", () => {
         schemaType.value = "Organization";
+
         renderFields();
+
+        dynamicFields.querySelectorAll("input").forEach((input) => {
+          input.value = "";
+        });
+
         generateJSONLD();
       });
     </script>


### PR DESCRIPTION
## What does this PR do?

Closes #561

Improves the JSON-LD Generator with two new Schema.org types, live field validation, and inline documentation for every property.

### Changes
- Added templates for LocalBusiness (address, phone, website) and Recipe (ingredients, numbered instructions, prep/cook time converted to ISO 8601 duration).
- Converted field metadata into a structured model per field (required, help text, input type) instead of ad-hoc id checks.
- Each field now shows a required (*) or optional badge, inline documentation text, and a live per-field error message.
- URL fields are validated as absolute http/https URLs; required fields are validated as non-empty.
- Added a validation summary banner above the preview that reflects whether the current schema is fully valid.
- `generateJSONLD` now reads values by field id directly (`fieldValue()`) instead of iterating all inputs generically, which was fragile for FAQ/Breadcrumb/Recipe fields that don't map 1:1 to top-level JSON-LD keys.
- Copy/Download now catch and surface failures via alert instead of letting them throw silently.
- Updated `data/tools.json` description and tags; ran `node scripts/sort-norm.js data/tools.json`.

## Type of Change

- [x] Enhancement to existing tool

## Screenshot

N/A — same two-panel layout; fields now show required/optional badges, help text, and inline error messages, plus a validation banner above the preview.

## Checklist

- [x] I have read the Contributing Guide
- [x] My branch follows the naming convention (`feat/description`)
- [x] I have tested my changes locally in at least one modern browser

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file