### PR TITLE
Fix source map explorer resize listener leak

### DIFF
--- a/tools/source-map-explorer.html
+++ b/tools/source-map-explorer.html
@@ -796,6 +796,7 @@
 
       let myChart = null;
       let currentMapData = null;
+      let chartResizeHandler = null;
 
       // Dual-view handling
       ["dragenter", "dragover", "dragleave", "drop"].forEach((eventName) => {
@@ -825,6 +826,10 @@
         if (myChart) {
           myChart.dispose();
           myChart = null;
+        }
+        if (chartResizeHandler) {
+          window.removeEventListener("resize", chartResizeHandler);
+          chartResizeHandler = null;
         }
       });
 
@@ -919,6 +924,10 @@
       }
 
       function renderChart(data) {
+        if (chartResizeHandler) {
+          window.removeEventListener("resize", chartResizeHandler);
+          chartResizeHandler = null;
+        }
         if (myChart) myChart.dispose();
         myChart = echarts.init(chartPanelContainer);
 
@@ -998,7 +1007,8 @@
           }
         });
 
-        window.addEventListener("resize", () => myChart.resize());
+        chartResizeHandler = () => myChart?.resize();
+        window.addEventListener("resize", chartResizeHandler);
       }
 
       function showToast(message, type = "info") {


### PR DESCRIPTION
## Summary
- keep a reference to the Source Map Explorer chart resize handler
- remove the previous resize listener before rendering a new chart
- remove the listener when resetting back to the landing view

Fixes #601.

## Validation
- npm ci
- npx prettier --check tools/source-map-explorer.html
- node inline-script syntax parse for tools/source-map-explorer.html
- git diff --check
- rg -n "Karim13014|claude-code@anthropic.com" .git .

Note: `node scripts/validate.js` currently fails on an unrelated baseline issue: `MISSING PNG: quests/transition-teleporter.png`.