### PR TITLE
fix: resolve broken JSON highlighting by deferring html escape

### DIFF
--- a/tools/websocket-sse-sandbox.html
+++ b/tools/websocket-sse-sandbox.html
@@ -872,9 +872,8 @@
 
       function formatJsonHighlight(obj) {
         let json = JSON.stringify(obj, null, 2);
-        json = escapeHtml(json);
 
-        // Highlight JSON matching values
+        // Highlight JSON matching values on the raw JSON where quotes are still intact
         return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g, function (match) {
           let cls = "json-number";
           if (/^"/.test(match)) {
@@ -888,7 +887,7 @@
           } else if (/null/.test(match)) {
             cls = "json-bracket"; // gray null
           }
-          return '<span class="' + cls + '">' + match + "</span>";
+          return '<span class="' + cls + '">' + escapeHtml(match) + "</span>";
         });
       }
 


### PR DESCRIPTION
### Description
This PR resolves an issue in the **WebSocket & SSE Sandbox** where JSON payloads were not being properly syntax-highlighted in the timeline logs. 
Fixes #597 
The bug occurred because `escapeHtml()` was being called on the raw JSON *before* the syntax-highlighting regex ran. This converted all double quotes (`"`) into `&quot;`, causing the regex (which looked for literal quotes) to fail to match keys and strings.

### Changes Made
- Moved the `escapeHtml()` call from before the regex to *inside* the regex replacer function.
- The regex now correctly identifies JSON syntax on the raw string, and safely HTML-escapes the matched segments before wrapping them in `<span class="...">` tags.

### Testing Instructions
1. Open `tools/websocket-sse-sandbox.html`.
2. Connect to an echo server and send a JSON payload like `{"test": "hello"}`.
3. Verify that both the keys (`"test"`) and strings (`"hello"`) are now properly colored in the timeline log.