### PR TITLE
fix: address XSS in sitemap generator and false positive in security 

### DIFF
--- a/tools/security-header-coach.html
+++ b/tools/security-header-coach.html
@@ -1137,7 +1137,10 @@
 
               // object-src checks
               if (!dirs["object-src"]) {
-                addCheck("warning", "Missing object-src Directive", "object-src fallback is missing. Specify object-src 'none' to block plugin vectors (Flash, Java).");
+                const fallback = dirs["default-src"] || [];
+                if (!fallback.includes("'none'") && !fallback.includes("'self'")) {
+                  addCheck("warning", "Missing object-src Directive", "object-src fallback is missing. Specify object-src 'none' to block plugin vectors (Flash, Java).");
+                }
               } else if (dirs["object-src"].includes("*") || dirs["object-src"].includes("https:")) {
                 addCheck("warning", "Permissive object-src Directive", "object-src allows loading plugin runtimes from any wildcard endpoint.");
               }


### PR DESCRIPTION
### Description
This PR addresses two separate issues in recently added tools:
Closes #599
1. **Sitemap Generator (DOM XSS):** Fixed a vulnerability where bulk importing a malicious URL containing double quotes could break out of the HTML `<input value="...">` attribute and execute arbitrary JavaScript.
2. **Security Header Coach (False Positive):** Fixed an issue where the scanner warned about a missing `object-src` directive even if the user had safely configured a strict `default-src` fallback (e.g., `default-src 'none'`).

### Changes Made
- **Sitemap Generator:** Wrapped `item.loc` with the existing `escapeXml()` helper inside the `renderAllCards()` template literal.
- **Security Header Coach:** Updated the `object-src` validation logic to verify if `default-src` safely covers the policy before emitting a warning.

### Testing Instructions
- **Sitemap Generator:** Bulk import `https://example.com/"><script>alert(1)</script>` and verify that it safely renders inside the input field without executing.
- **Security Header Coach:** Provide `Content-Security-Policy: default-src 'none'; script-src 'self'` as a mock header and verify that no "Missing object-src" warning is incorrectly generated.