### PR TITLE
Fix: html2canvas scroll truncation in Invoice Builder #712

### DIFF
--- a/design-system/invoice-receipt-builder.html
+++ b/design-system/invoice-receipt-builder.html
@@ -1018,6 +1018,8 @@ Thank you for your business!</textarea>
           scale: 2.5,
           useCORS: true,
           logging: false,
+          scrollY: 0,
+          windowScrollY: 0,
           backgroundColor: "#ffffff"
         })
           .then((canvas) => {


### PR DESCRIPTION
## What does this PR do?

Closes #712

Fixes an issue in `design-system/invoice-receipt-builder.html` where PNG image exports generated by `html2canvas` were top-truncated or blank if the right preview panel (`overflow-y-auto`) was scrolled down. Passing `scrollY: 0` and `windowScrollY: 0` into the `html2canvas` options forces canvas rendering to capture the entire `#invoice-sheet` cleanly from top to bottom regardless of scroll position.

## Type of Change

- [ ] New tool
- [ ] Enhancement to existing tool
- [x] Bug fix
- [ ] Documentation update
- [ ] Build system / infrastructure

## Screenshot

N/A (Code fix for html2canvas scroll parameters).

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser

### For new tools:

- [ ] The tool is a single self-contained `.html` file in the `tools/` folder
- [ ] The filename is kebab-case (e.g. `json-formatter.html`)
- [ ] I added an entry to `data/tools.json` with all required fields
- [ ] I added a screenshot as `tools/<tool-name>.png` next to the HTML file
- [ ] No JS frameworks (React, Vue, Angular, etc.) or heavy UI libraries (Bootstrap JS, jQuery, etc.)
- [ ] CDN links for lightweight libraries and fonts are fine — no copy-pasting library source code inline
- [ ] I ran `node scripts/sort-norm.js data/tools.json` to sort and normalize the tools registry
- [ ] I ran `node scripts/build.js` and verified the landing page renders correctly

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file