### PR TITLE
Fix: Uncaught TypeError on non-string tags in sort-norm.js

### DIFF
--- a/scripts/sort-norm.js
+++ b/scripts/sort-norm.js
@@ -27,7 +27,8 @@ const TAG_ALIASES = {
 };
 
 function normalizeTag(tag) {
-  const key = tag.trim().toLowerCase();
+  if (tag === null || tag === undefined) return "";
+  const key = String(tag).trim().toLowerCase();
   return TAG_ALIASES[key] || key;
 }
 
@@ -51,7 +52,7 @@ if (Array.isArray(data.tools)) {
 
   for (const tool of data.tools) {
     if (Array.isArray(tool.tags)) {
-      tool.tags = [...new Set(tool.tags.map(normalizeTag))].sort((a, b) => a.localeCompare(b));
+      tool.tags = [...new Set(tool.tags.map(normalizeTag).filter(Boolean))].sort((a, b) => a.localeCompare(b));
     }
 
     if (Array.isArray(tool.techStack)) {
@@ -66,7 +67,7 @@ if (Array.isArray(data.quests)) {
 
   for (const quest of data.quests) {
     if (Array.isArray(quest.tags)) {
-      quest.tags = [...new Set(quest.tags.map(normalizeTag))].sort((a, b) => a.localeCompare(b));
+      quest.tags = [...new Set(quest.tags.map(normalizeTag).filter(Boolean))].sort((a, b) => a.localeCompare(b));
     }
 
     if (Array.isArray(quest.techStack)) {
@@ -81,7 +82,7 @@ if (Array.isArray(data.designs)) {
 
   for (const design of data.designs) {
     if (Array.isArray(design.tags)) {
-      design.tags = [...new Set(design.tags.map(normalizeTag))].sort((a, b) => a.localeCompare(b));
+      design.tags = [...new Set(design.tags.map(normalizeTag).filter(Boolean))].sort((a, b) => a.localeCompare(b));
     }
 
     if (Array.isArray(design.techStack)) {


### PR DESCRIPTION
## What does this PR do?

Closes #714

Fixes a build pipeline crash in `scripts/sort-norm.js` where `normalizeTag(tag)` called `.trim()` directly on tags without verifying their data type. Converting input tags via `String(tag)` and filtering empty items ensures non-string tags (numbers like `2026`, `null`, or boolean values) are safely normalized without throwing an unhandled `TypeError`.

## Type of Change

- [ ] New tool
- [ ] Enhancement to existing tool
- [x] Bug fix
- [ ] Documentation update
- [x] Build system / infrastructure

## Screenshot

N/A (Node.js build script fix).

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser

### For new tools:

- [ ] The tool is a single self-contained `.html` file in the `tools/` folder
- [ ] The filename is kebab-case (e.g. `json-formatter.html`)
- [ ] I added an entry to `data/tools.json` with all required fields
- [ ] I added a screenshot as `tools/<tool-name>.png` next to the HTML file
- [ ] No JS frameworks (React, Vue, Angular, etc.) or heavy UI libraries (Bootstrap JS, jQuery, etc.)
- [ ] CDN links for lightweight libraries and fonts are fine — no copy-pasting library source code inline
- [ ] I ran `node scripts/sort-norm.js data/tools.json` to sort and normalize the tools registry
- [ ] I ran `node scripts/build.js` and verified the landing page renders correctly

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file