### PR TITLE
Fix: Detect orphan PNG screenshots in validate.js #742

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -54,6 +54,14 @@ function check(dir, jsonFile, key, label) {
         if (!items.some((t) => t.id === id)) issues.push(`ORPHAN: ${dir}/${f}`);
       });
 
+    // Orphan PNGs
+    fs.readdirSync(dirPath)
+      .filter((f) => f.endsWith(".png"))
+      .forEach((f) => {
+        const id = f.replace(/\.png$/, "");
+        if (!items.some((t) => t.id === id)) issues.push(`ORPHAN PNG: ${dir}/${f}`);
+      });
+
     // Case-mismatch PNGs
     fs.readdirSync(dirPath)
       .filter((f) => f.endsWith(".png"))


### PR DESCRIPTION
## What does this PR do?

Closes #742

Fixes an issue in `scripts/validate.js` where orphan file validation only checked `.html` files (`.endsWith(".html")`), but omitted checking for orphan `.png` screenshots. This allowed unreferenced or typo-named images to exist undetected in the repository.

Adding exact PNG ID validation ensures all screenshot files in `tools/`, `quests/`, `quizzes/`, `instruments/`, and `design-system/` correspond to registered item IDs in `data/*.json`.

## Type of Change

- [ ] New tool
- [ ] Enhancement to existing tool
- [x] Bug fix
- [ ] Documentation update
- [x] Build system / infrastructure

## Screenshot

N/A (Validation script fix).

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/praveenscience/One-File-Tools/blob/main/Contributing.md)
- [x] My branch follows the naming convention (`add/tool-name`, `feat/description`, or `fix/description`)
- [x] I have tested my changes locally in at least one modern browser

### For enhancements / bug fixes:

- [x] I have not introduced any external dependencies
- [x] The tool still works as a standalone single HTML file